### PR TITLE
Fix drone auto-deploy for the vite client

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -11,12 +11,19 @@ clone:
 steps:
 - name: rebuild
   commands:
+  # Ubuntu 18.04 (glibc 2.27) ships node 16; vite 6 needs node 18+.
+  # node 22 (glibc-217 unofficial build) lives at ~/.nodejs/current — prepend so node+npm resolve to it.
+  - export PATH=/home/dreamland/.nodejs/current/bin:$PATH
   - eval `ssh-agent -s`
   - ssh-add /home/dreamland/.ssh/drone
   - cd /var/www/mudjs
-  - git pull
+  # self-healing: snap the deploy tree to origin/dreamland from any state (fixes detached HEAD)
+  - git fetch origin dreamland
+  - git checkout -B dreamland origin/dreamland
+  - git reset --hard origin/dreamland
   - kill -9 $SSH_AGENT_PID
-  - npm ci --legacy-peer-deps
+  # package-lock.json is gitignored, so use install (not ci) to resolve from package.json
+  - npm install --legacy-peer-deps
   - npm run build
 
 - name: discord_failure

--- a/vite.config.js
+++ b/vite.config.js
@@ -30,6 +30,10 @@ function devMapperGraph() {
 export default defineConfig({
   plugins: [react(), devMapperGraph()],
   base: '/mudjs/', // 👈 путь, с которого будет искаться index.html и ассеты
+  build: {
+    // nginx serves /var/www/mudjs/build; vite defaults to dist/, so pin it to build/
+    outDir: 'build',
+  },
   resolve: {
     alias: {
       '@': path.resolve(__dirname, './src'),


### PR DESCRIPTION
Drone auto-deploy has been broken since the CRA→vite migration — live `/var/www/mudjs` was stuck at PR #100, so the new graph-mapper client never reached players. Three root causes, all fixed here:

- **outDir mismatch** — `vite build` writes to `dist/`, but nginx serves `/var/www/mudjs/build`. Pinned `build.outDir` to `build` in `vite.config.js`.
- **node too old** — Ubuntu 18.04 (glibc 2.27) ships node 16; vite 6 needs node 18+, and official node 18+ binaries require glibc 2.28. Installed a node 22 `glibc-217` unofficial build at `~/.nodejs/current` on the server and prepend it to `PATH` in the drone step.
- **broken git step + `npm ci`** — the deploy tree was on a detached HEAD, so `git pull` errored every run. Replaced with `git fetch` + `git checkout -B dreamland origin/dreamland` + `git reset --hard` (self-heals from any state). Swapped `npm ci` → `npm install --legacy-peer-deps` since `package-lock.json` is gitignored.