### PR TITLE
Fix per-prompt map re-render storm; surface fatal load errors

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,6 +6,41 @@
         <meta name="viewport" content="width=device-width, height=device-height, initial-scale=1, user-scalable=no, shrink-to-fit=no">
         <meta name="Description" content="DreamLand MUD (Мир Грез, Мир Снов, Dream Land, МУД, МАД) текстовая многопользовательская ролевая онлайн игра на тематику фентези">
 
+        <!-- Fatal-load reporter: if an uncaught error/rejection leaves #root empty (a blank
+             client, e.g. an old mobile WebKit choking on the bundle), surface the message
+             on-screen instead of a silent blank. Delayed 1.5s so a transient handled error
+             on an otherwise-working client never clobbers a rendered app. -->
+        <script>
+        (function () {
+          var lastErr = null;
+          function rootEmpty() { var r = document.getElementById('root'); return !r || r.childElementCount === 0; }
+          function record(msg) {
+            lastErr = msg;
+            setTimeout(function () {
+              if (!rootEmpty() || !lastErr) return;
+              try {
+                var d = document.getElementById('fatal-error');
+                if (!d) {
+                  d = document.createElement('pre');
+                  d.id = 'fatal-error';
+                  d.style.cssText = 'white-space:pre-wrap;word-break:break-word;padding:14px;margin:0;color:#ff8080;background:#161616;font:13px/1.45 monospace;position:fixed;top:0;left:0;right:0;bottom:0;z-index:99999;overflow:auto';
+                  (document.body || document.documentElement).appendChild(d);
+                }
+                d.textContent = 'DREAMLAND CLIENT FAILED TO LOAD\n\n' + lastErr;
+              } catch (_) {}
+            }, 1500);
+          }
+          window.addEventListener('error', function (e) {
+            record(e.error && e.error.stack ? e.error.stack
+              : (e.message + ' @ ' + (e.filename || '') + ':' + (e.lineno || 0) + ':' + (e.colno || 0)));
+          });
+          window.addEventListener('unhandledrejection', function (e) {
+            var r = e.reason;
+            record('UnhandledRejection: ' + (r && r.stack ? r.stack : (r && r.message ? r.message : String(r))));
+          });
+        })();
+        </script>
+
         <link href="https://fonts.googleapis.com/css?family=Roboto+Mono&amp;subset=cyrillic" rel="stylesheet" />
         <link href="css/bootswatch-cyborg.min.css" rel="stylesheet" type="text/css" />
         <link href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" rel="stylesheet" />

--- a/src/components/map.jsx
+++ b/src/components/map.jsx
@@ -20,7 +20,14 @@ const useLocation = () => {
       const locationChannel = new BroadcastChannel('location');
       locationChannel.onmessage = e => {
         if (e.data.what === 'location') {
-          setLocation(e.data.location);
+          const next = e.data.location || {};
+          // location.js re-broadcasts on EVERY rpc-prompt, so most messages repeat the
+          // same area+vnum. Keep the previous object identity when nothing changed — a
+          // fresh reference re-renders the whole map tree (incl. the heavy d3 graph) on
+          // every prompt, which is what made movement/typing hang.
+          setLocation(prev =>
+            prev && prev.area === next.area && prev.vnum === next.vnum ? prev : next
+          );
         }
       };
       return () => locationChannel.close();
@@ -231,6 +238,10 @@ export default function Map() {
   // only -- walking through them happens in-game and the map follows automatically.
   const handleCrossArea = useCallback(() => {}, []);
 
+  // Stable so memo(GraphMapPane) isn't defeated by a fresh inline closure each render.
+  const handleCloseDrawer = useCallback(() => setDrawerOpen(false), []);
+  const handleRequestAscii = useCallback(() => setModePersisted('ascii'), [setModePersisted]);
+
   const graphReady = mode === 'graph' && graph.status === 'ready' && graph.layout != null;
 
   return (
@@ -314,8 +325,8 @@ export default function Map() {
           onChangeZ={graph.setZFilter}
           onCrossArea={handleCrossArea}
           drawerOpen={drawerOpen}
-          onCloseDrawer={() => setDrawerOpen(false)}
-          onRequestAscii={() => setModePersisted('ascii')}
+          onCloseDrawer={handleCloseDrawer}
+          onRequestAscii={handleRequestAscii}
           toast={graph.toast}
         />
       )}

--- a/src/components/mapper/GraphMapPane.jsx
+++ b/src/components/mapper/GraphMapPane.jsx
@@ -6,11 +6,12 @@
  * and, since the tile is too narrow for a docked 340px aside, the room detail <SidePanel>
  * lives in a bottom overlay-drawer that slides over the map and is dismissable.
  */
+import { memo } from 'react';
 import { Map as GraphMap } from './Map';
 import { SidePanel } from './SidePanel';
 import { t } from './i18n.js';
 
-export default function GraphMapPane({
+function GraphMapPane({
   zoomApiRef,
   index,
   layout,
@@ -91,3 +92,7 @@ export default function GraphMapPane({
     </div>
   );
 }
+
+// Memoized: the parent (map.jsx) re-renders on drawer/toast/areaName ticks, but the heavy
+// d3 map body only needs to rebuild when its own props (layout/currentVnum/...) change.
+export default memo(GraphMapPane);

--- a/src/components/mapper/Map.tsx
+++ b/src/components/mapper/Map.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { memo, useEffect, useMemo, useRef, useState } from 'react';
 import { select } from 'd3-selection';
 import { zoom, zoomIdentity, type ZoomBehavior } from 'd3-zoom';
 import type { AreaLayout, Direction, ExitStyle, MapperIndex, PlacedExit, PlacedRoom } from './types.js';
@@ -350,7 +350,7 @@ function cardinalArc(
   return `M${sxp},${syp} Q${ctrlX},${ctrlY} ${txp},${typ}`;
 }
 
-export function Map({ layout, index, currentVnum, selectedVnum, activeZ, onSelectRoom, onSetCurrent, onCrossArea, onChangeZ, zFilter, zoomApiRef }: Props) {
+export const Map = memo(function Map({ layout, index, currentVnum, selectedVnum, activeZ, onSelectRoom, onSetCurrent, onCrossArea, onChangeZ, zFilter, zoomApiRef }: Props) {
   const svgRef = useRef<SVGSVGElement>(null);
   const gRef = useRef<SVGGElement>(null);
   const zoomRef = useRef<ZoomBehavior<SVGSVGElement, unknown> | null>(null);
@@ -812,7 +812,7 @@ export function Map({ layout, index, currentVnum, selectedVnum, activeZ, onSelec
       </g>
     </svg>
   );
-}
+});
 
 /** Direct line between corner ports for vertical exits when both layers visible.
  *  Source port: top-right corner (up) or bottom-left (down).


### PR DESCRIPTION
Two regressions in the freshly-deployed graph-mapper client.

## Desktop: ~30s freeze on every room move / general input lag
Players reported the client hangs on every keypress and freezes ~30s after each room change — even in **small** areas (Midgaard is only 188 rooms, so it isn't a graph-size problem).

Root cause: `location.js` re-broadcasts the player location on **every** `rpc-prompt` (which fires constantly), and `useLocation` called `setLocation(newObject)` each time. A fresh object reference re-rendered the entire map tree — including the heavy d3 `<Map>` SVG (~500 nodes) — on every prompt, saturating the main thread.

Fixes:
- `useLocation` keeps the previous location object identity when `area`+`vnum` are unchanged, so prompts that don't move the player no longer re-render.
- Wrap `GraphMapPane` and the d3 `Map` in `React.memo` (the author intended this — see the comment in `map.jsx` — but the `memo` was missing), and stabilize the two inline drawer/ascii callbacks with `useCallback` so the memo actually holds.

## Mobile: blank screen (diagnostic)
The mobile client renders blank even on a fresh load (not a cache issue), and there is no error boundary, so any uncaught error during init = silent blank. Added a tiny inline reporter in `index.html` that, if `#root` is still empty 1.5s after an uncaught error/rejection, prints the message on-screen. Delayed + root-empty-gated so it never clobbers a working client. This is to capture the actual iOS WebKit error; the real mobile fix lands in a follow-up once we see it.