### PR TITLE
Fix iOS blank screen: guard top-level Notification.permission

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,8 +31,14 @@
             }, 1500);
           }
           window.addEventListener('error', function (e) {
-            record(e.error && e.error.stack ? e.error.stack
-              : (e.message + ' @ ' + (e.filename || '') + ':' + (e.lineno || 0) + ':' + (e.colno || 0)));
+            var err = e.error;
+            // WebKit stacks omit the error name/message, so capture them explicitly.
+            var head = err && (err.name || err.message)
+              ? (err.name || 'Error') + ': ' + (err.message || '')
+              : (e.message || 'Unknown error');
+            var loc = err && err.stack ? err.stack
+              : (e.filename || '') + ':' + (e.lineno || 0) + ':' + (e.colno || 0);
+            record(head + '\n' + loc);
           });
           window.addEventListener('unhandledrejection', function (e) {
             var r = e.reason;

--- a/src/notify.js
+++ b/src/notify.js
@@ -1,6 +1,10 @@
 import $ from 'jquery';
 
-let notificationPermission = Notification.permission;
+// iOS Safari/WebKit has no Notification API, so this runs at module eval before any
+// guard could help -- reading Notification.permission unguarded threw a ReferenceError
+// during init and blanked the whole client on iPhone. Feature-detect first.
+let notificationPermission =
+  'Notification' in window ? Notification.permission : 'denied';
 
 // Один раз реєструємо обробник після першого кліку
 $(document).one('click', () => {


### PR DESCRIPTION
The mobile client rendered blank because `notify.js` read `Notification.permission` at module-eval time without a guard. iOS Safari/WebKit has no `Notification` API in normal browser tabs, so the access threw `ReferenceError: Can't find variable: Notification` during init — before the file's own `'Notification' in window` guards could run — which crashed the whole bundle and left `#root` empty. Desktop Safari and Chromium expose `Notification`, so they were unaffected (explaining "works on desktop, blank on mobile").

Pinpointed via the fatal-load reporter added in #107, which surfaced `module code@…index-….js:146:1932` → `let notificationPermission = Notification.permission`.

Fix: feature-detect (`'Notification' in window`) before reading `.permission`. Also enriched the reporter to print the error name/message (WebKit stacks omit them) for one-shot diagnosis next time.