### PR TITLE
Full-screen editors, Monokai theme, no error markers, 80-col guides

### DIFF
--- a/src/cs.js
+++ b/src/cs.js
@@ -1,6 +1,7 @@
 import $ from 'jquery';
 import loader from '@monaco-editor/loader';
 import { rpccmd } from './websock.js';
+import { defineMonokai } from './monaco-monokai.js';
 
 function fixindent(fn, str) {
   const lines = str.replace(/\r/g, '').split('\n');
@@ -26,7 +27,14 @@ let currentFile = null;
 
 $(document).ready(function () {
   loader.init().then(monaco => {
-    monaco.languages.setMonarchTokensProvider('javascript', {
+    defineMonokai(monaco);
+
+    // Fenia is not JavaScript: register it as its own language so Monaco's
+    // built-in JS/TS worker never validates it. The worker used to flag
+    // valid Fenia (e.g. a statement starting with `.tmp...`) as a JS syntax
+    // error and paint red markers in the overview ruler.
+    monaco.languages.register({ id: 'fenia' });
+    monaco.languages.setMonarchTokensProvider('fenia', {
       keywords: [
         'if',
         'else',
@@ -114,14 +122,17 @@ $(document).ready(function () {
     const editorElement = $('#cs-modal .editor')[0];
     monacoEditor = monaco.editor.create(editorElement, {
       value: '',
-      language: 'javascript',
-      theme: 'vs-dark',
+      language: 'fenia',
+      theme: 'monokai',
       fontSize: 16,
       lineNumbers: 'off',
       wordWrap: 'on',
       minimap: { enabled: false },
       automaticLayout: true,
       scrollBeyondLastLine: false,
+      overviewRulerLanes: 0,
+      overviewRulerBorder: false,
+      hideCursorInOverviewRuler: true,
       padding: { top: 20, bottom: 20 },
       tabSize: 4,
       insertSpaces: false,

--- a/src/main.css
+++ b/src/main.css
@@ -38,6 +38,7 @@ body {
 
 .terminal-wrap {
   overflow-y: scroll;
+  overflow-x: hidden;
   -webkit-overflow-scrolling: touch;
   background-color: #121212;
   padding: 1px;
@@ -52,6 +53,24 @@ body {
   background-color: #121212;
   color: #d3d7cf;
   white-space: pre-wrap;
+  /* Anchor the 80-column guide and let it span the full visible height even
+     when there is little output. */
+  position: relative;
+  min-height: 100%;
+}
+
+/* Faint guide at the 80-character mark — the MUD's terminal width. The font is
+   monospace, so 80ch is exactly column 80. Clipped horizontally by
+   .terminal-wrap's overflow-x on narrow screens. */
+.terminal::after {
+  content: '';
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 80ch;
+  width: 1px;
+  background-color: #2e2e2e;
+  pointer-events: none;
 }
 
 #input input {
@@ -356,26 +375,6 @@ td.v-bottom {
  * Settings and editors modal windows.
  */
 
-#textedit-modal.webeditor .modal-content {
-  width: 70%;
-  background-color: #2b2b2b;
-  border-radius: 12px;
-  box-shadow: 0 0 25px rgba(0, 0, 0, 0.5);
-  overflow: hidden;
-}
-
-#textedit-modal.webeditor .modal-dialog {
-  max-width: 900px;
-  margin: 2rem auto;
-}
-
-#textedit-modal.webeditor .modal-body {
-  padding: 20px;
-  font-family: 'Georgia', serif;
-  font-size: 16px;
-  color: #ddd;
-}
-
 .webeditor .modal-dialog {
   max-width: 100%;
 }
@@ -392,6 +391,57 @@ td.v-bottom {
   .webeditor .modal-dialog {
     max-width: 80%;
   }
+}
+
+/*
+ * Full-screen layout for the two editors only (#cs-modal, #textedit-modal).
+ * The settings modal is also .webeditor but must keep its sized box, so these
+ * rules are scoped by id, not by the shared .webeditor class. The flex chain
+ * (content -> body -> form-group -> editor) lets Monaco fill the viewport;
+ * automaticLayout: true picks up the resize.
+ */
+#cs-modal .modal-dialog,
+#textedit-modal.webeditor .modal-dialog {
+  max-width: 100%;
+  width: 100%;
+  height: 100%;
+  margin: 0;
+}
+
+#cs-modal .modal-content,
+#textedit-modal.webeditor .modal-content {
+  width: 100%;
+  height: 100%;
+  border: 0;
+  border-radius: 0;
+  display: flex;
+  flex-direction: column;
+  background-color: #272822;
+  overflow: hidden;
+}
+
+#cs-modal .modal-body,
+#textedit-modal.webeditor .modal-body {
+  display: flex;
+  flex-direction: column;
+  flex: 1 1 auto;
+  min-height: 0;
+  padding: 0;
+}
+
+#cs-modal .form-group {
+  display: flex;
+  flex-direction: column;
+  flex: 1 1 auto;
+  min-height: 0;
+  margin-bottom: 0;
+}
+
+#cs-modal .editor,
+#textedit-modal .editor {
+  flex: 1 1 auto;
+  min-height: 0;
+  height: auto;
 }
 
 .btn-ctrl {
@@ -431,8 +481,7 @@ td.v-bottom {
 }
 
 #textedit-modal .editor {
-  height: 500px;
-  border-radius: 8px;
+  border-radius: 0;
   overflow: hidden;
   font-family: 'Georgia', serif !important;
   background-color: black;

--- a/src/monaco-monokai.js
+++ b/src/monaco-monokai.js
@@ -1,0 +1,33 @@
+// Monokai colour scheme for Monaco, matching the palette the editors used
+// back when they ran on Ace (brace/theme/monokai). Shared by the Fenia code
+// editor (cs.js) and the plain-text editor (textedit.js). defineTheme is
+// idempotent, so calling this from both modules is safe.
+export function defineMonokai(monaco) {
+  monaco.editor.defineTheme('monokai', {
+    base: 'vs-dark',
+    inherit: true,
+    rules: [
+      { token: '', foreground: 'f8f8f2', background: '272822' },
+      { token: 'comment', foreground: '88846f' },
+      { token: 'string', foreground: 'e6db74' },
+      { token: 'string.escape', foreground: 'ae81ff' },
+      { token: 'string.invalid', foreground: 'f92672' },
+      { token: 'number', foreground: 'ae81ff' },
+      { token: 'keyword', foreground: 'f92672' },
+      { token: 'operator', foreground: 'f92672' },
+      { token: 'identifier', foreground: 'f8f8f2' },
+      { token: 'type', foreground: '66d9ef' },
+    ],
+    colors: {
+      'editor.background': '#272822',
+      'editor.foreground': '#f8f8f2',
+      'editorLineNumber.foreground': '#90908a',
+      'editorCursor.foreground': '#f8f8f0',
+      'editor.selectionBackground': '#49483e',
+      'editor.lineHighlightBackground': '#3e3d32',
+      'editorWhitespace.foreground': '#3b3a32',
+      'editorIndentGuide.background': '#3b3a32',
+      'editorRuler.foreground': '#3b3a32',
+    },
+  });
+}

--- a/src/textedit.js
+++ b/src/textedit.js
@@ -2,6 +2,7 @@ import $ from 'jquery';
 import loader from '@monaco-editor/loader';
 import 'devbridge-autocomplete';
 import { rpccmd } from './websock';
+import { defineMonokai } from './monaco-monokai.js';
 
 let monacoEditor;
 
@@ -40,13 +41,20 @@ function initHelpIds() {
 
 $(document).ready(function () {
   loader.init().then(monaco => {
+    defineMonokai(monaco);
+
     const editorElement = $('#textedit-modal .editor')[0];
 
     monacoEditor = monaco.editor.create(editorElement, {
       value: '',
       language: 'plaintext',
-      theme: 'vs-dark',
-      wordWrap: 'on',
+      theme: 'monokai',
+      // In-game help/description text is laid out for an 80-column terminal,
+      // so wrap exactly at column 80 and draw a guide there to match.
+      wordWrap: 'bounded',
+      wordWrapColumn: 80,
+      wrappingIndent: 'same',
+      rulers: [80],
       lineNumbers: 'off',
       minimap: { enabled: false },
       scrollBeyondLastLine: false,
@@ -54,7 +62,6 @@ $(document).ready(function () {
       fontFamily: 'serif',
       padding: { top: 20, bottom: 20 },
       automaticLayout: true,
-      minimap: { enabled: false },
     });
 
     $('#rpc-events').on('rpc-editor_open', function (e, text, arg) {


### PR DESCRIPTION
## What

Web client editor + terminal tweaks.

### Code editor & plain-text editor
1. **Full-screen on every viewport (incl. mobile).** Full-screen CSS scoped to `#cs-modal` / `#textedit-modal` so the settings modal (also `.webeditor`) keeps its sized box. Editor fills the modal through a flex chain (`modal-content → modal-body → form-group → editor`); `automaticLayout: true` handles the resize.
2. **No more red "rectangles" in the gutter.** The code editor used `language: 'javascript'`, so Monaco's built-in JS/TS worker validated Fenia and flagged valid constructs (e.g. a statement starting with `.tmp.system...`) as syntax errors, painting red markers in the overview ruler. Fenia is now registered as its own Monaco language → no worker → no markers. Overview ruler lanes disabled as well.
3. **Monokai restored.** Both editors used `brace/theme/monokai` on Ace; after the Monaco migration they were on `vs-dark`. New shared `defineMonokai()` theme module reapplies Monokai to both.

### Plain-text editor only
4. Ruler at **column 80** + wrap exactly at 80 (`wordWrap: 'bounded'`, `wordWrapColumn: 80`) to match the in-game terminal width.

### Main terminal
- Faint dark-gray vertical guide at the **80-character mark** (`.terminal::after` at `left: 80ch`; monospace font → exact column 80). `overflow-x: hidden` on the wrap so the guide can't trigger a horizontal scrollbar on narrow screens.

## Notes
`npm run build` passes. Visual behavior (full-screen layout, theme, wrapping) wants a real look in the running client before merge.