### PR TITLE
Disable Monaco Unicode highlight; monospace font for text editor

### DIFF
--- a/src/cs.js
+++ b/src/cs.js
@@ -133,6 +133,13 @@ $(document).ready(function () {
       overviewRulerLanes: 0,
       overviewRulerBorder: false,
       hideCursorInOverviewRuler: true,
+      // Fenia strings are full of Cyrillic; stop Monaco boxing/hovering
+      // "ambiguous" characters (о vs o, б vs 6, etc.).
+      unicodeHighlight: {
+        ambiguousCharacters: false,
+        invisibleCharacters: false,
+        nonBasicASCII: false,
+      },
       padding: { top: 20, bottom: 20 },
       tabSize: 4,
       insertSpaces: false,

--- a/src/main.css
+++ b/src/main.css
@@ -483,7 +483,7 @@ td.v-bottom {
 #textedit-modal .editor {
   border-radius: 0;
   overflow: hidden;
-  font-family: 'Georgia', serif !important;
+  font-family: 'Roboto Mono', monospace !important;
   background-color: black;
   color: white;
 }

--- a/src/textedit.js
+++ b/src/textedit.js
@@ -59,7 +59,15 @@ $(document).ready(function () {
       minimap: { enabled: false },
       scrollBeyondLastLine: false,
       fontSize: 16,
-      fontFamily: 'serif',
+      // Monospace (same font as the in-game terminal) so the column-80 ruler
+      // and wrap line up with real character columns and mirror what players
+      // see. The text is mostly Cyrillic, so also turn off Unicode highlight.
+      fontFamily: "'Roboto Mono', monospace",
+      unicodeHighlight: {
+        ambiguousCharacters: false,
+        invisibleCharacters: false,
+        nonBasicASCII: false,
+      },
       padding: { top: 20, bottom: 20 },
       automaticLayout: true,
     });


### PR DESCRIPTION
Follow-up to #111.

- **Disable Unicode highlight in both editors.** Monaco was boxing and hover-warning about "ambiguous" Cyrillic characters (`о` vs `o`, `б` vs `6`, …) — the boxes, hovers, and "Configure Unicode Highlight Options" widget. The content is mostly Cyrillic, so it's pure noise. Turned off `ambiguousCharacters` / `invisibleCharacters` / `nonBasicASCII`.
- **Monospace font for the plain-text editor.** It was on a proportional serif (`Georgia`), which made the column-80 ruler + wrap from #111 meaningless. Switched to `'Roboto Mono'` (the in-game terminal font, already loaded with the cyrillic subset) so columns line up and the editor mirrors what players see.

`npm run build` passes.