### PR TITLE
areas: add Eastern Road to the web-client area list

### DIFF
--- a/src/data/areas.json
+++ b/src/data/areas.json
@@ -74,6 +74,7 @@
 {"name": "Маскарад", "file": "masquerade.are"},
 {"name": "Матушка Гусыня", "file": "mgoose.are"},
 {"name": "Миден&apos;нир", "file": "midennir.are"},
+{"name": "Восточная Дорога", "file": "easternroad.are"},
 {"name": "Мидгаард", "file": "midgaard.are"},
 {"name": "Лихолесье", "file": "mirkwd2.are"},
 {"name": "Королевство Зеркал", "file": "mirror2.are"},


### PR DESCRIPTION
Adds the new `easternroad.are` zone (split out of Midennir, help 5085) to `src/data/areas.json` so `manip.js` resolves its display name ("Восточная Дорога") on the map panel instead of falling back to an empty string. Hand-maintained list; deploys via drone, hard-refresh to bust cache.