### PR TITLE
mapper: no phantom up-stub at the target of a one-way vertical

### DIFF
--- a/src/components/mapper/Map.tsx
+++ b/src/components/mapper/Map.tsx
@@ -910,6 +910,11 @@ function renderVerticalStub(
   const toP = layout.placed[edge.to];
   if (!fromP || !toP) return null;
 
+  // A one-way vertical (e.g. a drop INTO a maze) is not traversable from the target end, so
+  // don't draw an up/down stub there implying you can climb back — only the source advertises
+  // it. Without this, every `A down→B` with no return shows a phantom "up" exit at B.
+  if (!edge.bidirectional && !fromIsAnchor) return null;
+
   const anchorP = fromIsAnchor ? fromP : toP;
   const otherVnum = fromIsAnchor ? edge.to : edge.from;
   const dirIsUp = fromIsAnchor ? edge.dir === 'up' : edge.dir === 'down';


### PR DESCRIPTION
A one-way `A down->B` drew an 'up' stub at B (e.g. catacomb maze 2066 showed up exits that don't exist). Suppress the stub at the target end of a non-bidirectional vertical; the source still shows the drop, and the both-visible line already uses the one-way chevron. Hard-refresh to bust the bundle cache after deploy.