### PR TITLE
web client: persist panel/layout state, ASCII-map notice, fix resize crash

### DIFF
--- a/src/app.jsx
+++ b/src/app.jsx
@@ -54,6 +54,29 @@ const getResponsiveLayout = (bigScreen, hugeScreen) => {
   };
 };
 
+// Persist the terminal/panel/map split when a resize-drag ends. We read the percentages
+// straight off the mosaic layout tree (no DOM querying), so this never touches a missing
+// #map-wrap the way the old splitter handler did. Only the full three-pane (huge-screen)
+// tree carries all three widths; smaller layouts use a fixed split and aren't persisted.
+const persistLayout = value => {
+  if (!value || typeof value !== 'object') return;
+  const inner = value.second;
+  if (!inner || typeof inner !== 'object' || inner.second !== 'map') return;
+  const outerPct = value.splitPercentage;
+  const innerPct = inner.splitPercentage;
+  if (typeof outerPct !== 'number' || typeof innerPct !== 'number') return;
+
+  const terminal = outerPct;
+  const rest = 100 - outerPct;
+  const panel = rest * (innerPct / 100);
+  const map = rest - panel;
+
+  propertiesStorage['terminalLayoutWidth'] = terminal;
+  propertiesStorage['panelLayoutWidth'] = panel;
+  propertiesStorage['mapLayoutWidth'] = map;
+  localStorage.properties = JSON.stringify(propertiesStorage);
+};
+
 export default function App() {
   const bigScreen = useMediaQuery('(min-width:600px)');
   const hugeScreen = useMediaQuery('(min-width:1280px)');
@@ -87,6 +110,7 @@ export default function App() {
         <Mosaic
           value={layout}
           onChange={setLayout}
+          onRelease={persistLayout}
           renderTile={(id, path) => (
             <MosaicWindow
               path={path}

--- a/src/components/map.jsx
+++ b/src/components/map.jsx
@@ -165,9 +165,18 @@ const AsciiMapBody = ({ location, apiRef }) => {
     };
   });
 
+  // useMapSource resolves to '' on fetch failure or an empty body. Without a notice the
+  // <pre> just renders blank, which reads as a broken panel; show why the map is missing.
+  const mapUnavailable = mapSource === '';
+
   return (
     <div id="map-wrap">
       <div id="map">
+        {mapUnavailable && (
+          <div className="dl-mapper-notice">
+            <p>{t.noAsciiMap}</p>
+          </div>
+        )}
         <pre ref={mapElement} />
       </div>
     </div>

--- a/src/components/mapper/i18n.ts
+++ b/src/components/mapper/i18n.ts
@@ -33,6 +33,7 @@ export interface Strings {
   // integration (mudjs)
   noGraphMap: string;
   graphMapError: string;
+  noAsciiMap: string;
   showAscii: string;
   closePanel: string;
   // search
@@ -93,6 +94,7 @@ const ru: Strings = {
   loadingArea: 'Загрузка зоны',
   noGraphMap: 'Графической карты для этой зоны пока нет.',
   graphMapError: 'Не удалось загрузить карту зоны.',
+  noAsciiMap: 'ASCII-карты для этой зоны нет.',
   showAscii: 'Показать ASCII-карту',
   closePanel: 'Закрыть',
   searchRooms: 'поиск комнат…',
@@ -146,6 +148,7 @@ const en: Strings = {
   loadingArea: 'Loading area',
   noGraphMap: 'No graphical map for this zone yet.',
   graphMapError: 'Failed to load the zone map.',
+  noAsciiMap: 'No ASCII map for this zone.',
   showAscii: 'Show ASCII map',
   closePanel: 'Close',
   searchRooms: 'search rooms…',

--- a/src/components/windowletsPanel/areaQuestItem.jsx
+++ b/src/components/windowletsPanel/areaQuestItem.jsx
@@ -13,7 +13,7 @@ export default function AreaQuestItem(prompt) {
         : raw
 
     return (
-        <PanelItem title={<span>{prompt.aq.t}</span>}>
+        <PanelItem storageKey="areaquest" title={<span>{prompt.aq.t}</span>}>
             <div id="questor-table" data-hint="hint-questor">
                 <p className="fgbw">{body}</p>
             </div>

--- a/src/components/windowletsPanel/groupItem.jsx
+++ b/src/components/windowletsPanel/groupItem.jsx
@@ -20,7 +20,7 @@ const TeamMate = (stats) => {
 
 export default function GroupItem(prompt) {
 
-    return <PanelItem title={'Группа ' + prompt.group.ln} collapsed={true} >
+    return <PanelItem storageKey="group" title={'Группа ' + prompt.group.ln} collapsed={true} >
             <div id="group-table">
                 <table>
                     <thead>

--- a/src/components/windowletsPanel/panelItem.jsx
+++ b/src/components/windowletsPanel/panelItem.jsx
@@ -1,12 +1,33 @@
 import React, { useState } from 'react'
 import Collapse from '@mui/material/Collapse';
 
+// Persist each panel's collapsed/expanded state across sessions in localStorage, so players
+// don't have to re-collapse the same panels on every login. Keyed by an explicit storageKey
+// when the panel's title is dynamic (group/quest), otherwise by the stable string title.
+const storageKeyFor = props => {
+    if (props.storageKey) return 'panel.collapsed.' + props.storageKey;
+    if (typeof props.title === 'string') return 'panel.collapsed.' + props.title;
+    return null;
+};
 
 export default function PanelItem(props) {
-    const [collapsed, setCollapsed] = useState(props.collapsed || false);
+    const storeKey = storageKeyFor(props);
+
+    const [collapsed, setCollapsed] = useState(() => {
+        if (storeKey != null) {
+            const saved = localStorage.getItem(storeKey);
+            if (saved != null) return saved === '1';
+        }
+        return props.collapsed || false;
+    });
+
     const toggle = e => {
         e.preventDefault();
-        setCollapsed(!collapsed);
+        setCollapsed(prev => {
+            const next = !prev;
+            if (storeKey != null) localStorage.setItem(storeKey, next ? '1' : '0');
+            return next;
+        });
     };
 
     return <div className="table-wrapper">

--- a/src/components/windowletsPanel/questorItem.jsx
+++ b/src/components/windowletsPanel/questorItem.jsx
@@ -5,7 +5,7 @@ import PanelItem from "./panelItem"
 export default function QuestorItem(prompt) {
 
     return (
-        <PanelItem title={<span>{'Задание квестора: '}<span className='fgby'> {prompt.q.t} </span>{' мин'}</span>}>
+        <PanelItem storageKey="questor" title={<span>{'Задание квестора: '}<span className='fgby'> {prompt.q.t} </span>{' мин'}</span>}>
             <div id="questor-table" data-hint="hint-questor">
                 <p className="fgbw">{prompt.q.i}</p>
             </div>

--- a/src/main.js
+++ b/src/main.js
@@ -126,15 +126,8 @@ $(document).ready(function () {
     changeFontSize(-fontDelta);
   });
 
-  /* Save layout size */
-  $('.layout-splitter').on('click', function (e) {
-    propertiesStorage['terminalLayoutWidth'] =
-      document.querySelector('.terminal-wrap').getBoundingClientRect().width ||
-      0;
-    propertiesStorage['panelLayoutWidth'] =
-      document.querySelector('#panel-wrap').getBoundingClientRect().width || 0;
-    propertiesStorage['mapLayoutWidth'] =
-      document.querySelector('#map-wrap').getBoundingClientRect().width || 0;
-    localStorage.properties = JSON.stringify(propertiesStorage);
-  });
+  // Layout-width persistence now lives in app.jsx (Mosaic onRelease), which reads the split
+  // off the layout tree instead of querying #map-wrap — the dead '.layout-splitter' handler
+  // here both never fired (react-mosaic uses .mosaic-split) and crashed on a missing #map-wrap
+  // when the map pane was hidden at narrow widths.
 });


### PR DESCRIPTION
Four player-reported web-client fixes, bundled.

### Panels not remembering collapse state (Ril, Taiphoen)
`PanelItem` held `collapsed` in ephemeral React state, so every panel reset on each login. Now persisted in `localStorage`, keyed by the stable string title (or an explicit `storageKey` for panels with a dynamic title: group / areaquest / questor).

### Layout widths not saving (Taiphoen)
The `terminal/panel/map` split was never persisted: the `.layout-splitter` click handler in `main.js` targeted a class react-mosaic never renders (it uses `.mosaic-split`), so it bound to nothing. Replaced with a `Mosaic` `onRelease` handler in `app.jsx` that reads the split percentages off the layout tree and stores them.

### Resize crash when map pane hidden (Ochokochi)
The same dead handler also ran `querySelector('#map-wrap').getBoundingClientRect()`, which threw `Cannot read properties of null (reading 'getBoundingClientRect')` at narrow widths (600–1280px) where the map pane isn't mounted. The new tree-based `onRelease` never queries the DOM, so it can't hit a missing `#map-wrap`.

### ASCII map: no feedback when unavailable (Taiphoen)
When the ASCII map source 404s or comes back empty, the `<pre>` rendered blank with no explanation. Now shows a "no ASCII map for this zone" notice.