### PR TITLE
mapper: render room text in the player's gender

### DIFF
--- a/src/components/map.jsx
+++ b/src/components/map.jsx
@@ -26,7 +26,12 @@ const useLocation = () => {
           // fresh reference re-renders the whole map tree (incl. the heavy d3 graph) on
           // every prompt, which is what made movement/typing hang.
           setLocation(prev =>
-            prev && prev.area === next.area && prev.vnum === next.vnum ? prev : next
+            prev &&
+            prev.area === next.area &&
+            prev.vnum === next.vnum &&
+            prev.sex === next.sex
+              ? prev
+              : next
           );
         }
       };

--- a/src/components/mapper/flexer.js
+++ b/src/components/mapper/flexer.js
@@ -1,0 +1,50 @@
+/**
+ * Resolve Dreamland gender (flexer) switches in graph text for a given player sex.
+ *
+ * The graph builder (dreamland_mapper build-graph.ts) preserves these switches verbatim
+ * instead of baking one gender, so each player sees their own form. Colour codes are
+ * already stripped at build time; only the {S…} switches remain.
+ *
+ *   {Sf<f>{Sm<m>{Sx   ->  <f> for female, <m> for male
+ *   {Sm<m>{Sf<f>{Sx   ->  <m> for male,   <f> for female
+ *   {Sf<f>{Sx         ->  <f> for female, ''  for male   (the male form is the bare stem)
+ *   {Sm<m>{Sx         ->  <m> for male,   ''  for female
+ *
+ * Unknown/neutral sex falls back to the male form, matching the engine's default and the
+ * map's previous (male-baked) behaviour.
+ */
+export function resolveFlexer(text, sex) {
+  if (text == null || text.indexOf('{S') === -1) return text;
+  const want = sex === 'female' ? 'f' : 'm';
+  return text.replace(
+    /\{S([mf])([^{]*)(?:\{S([mf])([^{]*))?\{Sx/g,
+    (_match, g1, t1, g2, t2) => {
+      if (g1 === want) return t1;
+      if (g2 === want) return t2 || '';
+      return '';
+    }
+  );
+}
+
+/**
+ * Return a copy of an area layout with every room name/description resolved for `sex`.
+ * Layouts without any flexer switch (the common case) are returned by identity, so the
+ * heavy d3 map and downstream effects don't see a fresh object on every sex/area tick.
+ */
+export function resolveLayoutFlexer(layout, sex) {
+  if (layout == null) return layout;
+  let touched = false;
+  const rooms = {};
+  for (const vnum in layout.rooms) {
+    const room = layout.rooms[vnum];
+    const name = resolveFlexer(room.name, sex);
+    const description = resolveFlexer(room.description, sex);
+    if (name !== room.name || description !== room.description) {
+      rooms[vnum] = { ...room, name, description };
+      touched = true;
+    } else {
+      rooms[vnum] = room;
+    }
+  }
+  return touched ? { ...layout, rooms } : layout;
+}

--- a/src/components/mapper/useGraphMapper.js
+++ b/src/components/mapper/useGraphMapper.js
@@ -14,6 +14,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import { findPath, pathToSpeedwalk } from './pathfinding.js';
 import { DIR_LETTERS } from './types.js';
 import { t } from './i18n.js';
+import { resolveLayoutFlexer } from './flexer.js';
 import { send } from '../../websock.js';
 
 const GRAPH_BASE = '/maps/graph';
@@ -66,14 +67,22 @@ export function useGraphMapper(location, enabled) {
   const areaFile = areaKey(location.area);
   const currentVnum =
     location.vnum != null && location.vnum !== '' ? Number(location.vnum) : null;
+  // Player sex drives gender (flexer) resolution in room text; absent until the server
+  // sends it, in which case resolveLayoutFlexer falls back to the male form.
+  const sex = location.sex;
 
   const [index, setIndex] = useState(null);
-  const [layout, setLayout] = useState(null);
+  const [rawLayout, setRawLayout] = useState(null);
   const [selectedVnum, setSelectedVnum] = useState(null);
   const [zFilter, setZFilter] = useState(0);
   const [toast, setToast] = useState(null);
   // 'idle' | 'loading' | 'ready' | 'missing' | 'error' — drives the pane's fallback notice.
   const [status, setStatus] = useState('idle');
+
+  // Resolve gender (flexer) switches in room text for the current player. Memoized so an
+  // area without any flexer keeps its identity (resolveLayoutFlexer returns it unchanged),
+  // and re-resolves only when the area or the player's sex actually changes.
+  const layout = useMemo(() => resolveLayoutFlexer(rawLayout, sex), [rawLayout, sex]);
 
   // Cross-area index (vnum -> area, area names): loaded once, lazily, when first enabled.
   useEffect(() => {
@@ -108,12 +117,12 @@ export function useGraphMapper(location, enabled) {
       .then((l) => {
         if (cancelled) return;
         rebaseZ(l); // ground layer -> z=0 before choosing the active layer
-        setLayout(l);
+        setRawLayout(l);
         setStatus('ready');
       })
       .catch((err) => {
         if (cancelled) return;
-        setLayout(null);
+        setRawLayout(null);
         setStatus(err.message === 'missing' ? 'missing' : 'error');
         if (err.message !== 'missing') console.warn('[mapper] area load failed', areaFile, err);
       });

--- a/src/location.js
+++ b/src/location.js
@@ -4,6 +4,9 @@ import placeholders from './data/placeholders.json' assert { type: 'json' };
 
 const sessionId = getSessionId();
 var lastLocation, locationChannel;
+// Remembered across prompts: the server may send the player's sex once (delta prompt), so
+// hold the last value seen and keep attaching it to every location broadcast.
+var lastSex;
 
 if ('BroadcastChannel' in window) {
   locationChannel = new BroadcastChannel('location');
@@ -60,9 +63,11 @@ function createPlaceholder(loc) {
 
 $(document).ready(function () {
   $('#rpc-events').on('rpc-prompt', function (e, b) {
+    if (b.sex != null) lastSex = b.sex;
     var loc = {
       area: b.area,
       vnum: b.vnum,
+      sex: lastSex,
     };
     $('#input input').attr('placeholder', createPlaceholder(loc));
     bcastLocation(loc);


### PR DESCRIPTION
The graph map's side panel showed room descriptions in a single fixed gender — e.g. a female character standing in the void still read **"Ты полностью дезориентирован"** (masculine). Some forms were also mangled by the build step (`оторваннmый`).

Root cause: the graph builder resolved the engine's `{Sm}{Sf}{Sx` gender (flexer) switches to the male form at build time, and the client had no notion of player sex.

This is the **client half**. Paired with dreamland_mapper, which now preserves the switches verbatim instead of baking one gender.

### What this does
- **`flexer.js`** — `resolveFlexer(text, sex)` picks the right form; `resolveLayoutFlexer(layout, sex)` applies it across a layout's room names/descriptions, returning the layout by identity when it contains no switches (so the heavy d3 map doesn't churn).
- **`useGraphMapper`** — derives the displayed layout from the raw graph + player sex via `useMemo` (re-resolves only on area or sex change).
- **`location.js`** — remembers the player's sex from the prompt and attaches it to every location broadcast, so a delta prompt that sends it once still keeps it available.
- **`map.jsx`** — includes sex in the location de-dup so a sex change re-renders.

### Safe to ship before the server change
Sex isn't sent by the server yet (separate C++ PR). Until it is, `resolveFlexer` falls back to the **male** form — identical to today's behaviour. And old (marker-free) graphs pass through unchanged, so this can deploy before graphs are regenerated with markers.