### PR TITLE
web client: self-update on new build + live-refresh map data

### DIFF
--- a/src/autoupdate.js
+++ b/src/autoupdate.js
@@ -1,0 +1,106 @@
+/**
+ * Self-update: keep an open client from running a stale bundle after a deploy, so players
+ * (and we) don't have to hard-refresh to see a new map/UI.
+ *
+ * Each build stamps a BUILD_ID into the bundle (__BUILD_ID__) and into a sibling version.json
+ * (see vite.config.js). The running client polls version.json (with no-store, so the poll
+ * itself is never cached) and, when it sees a newer build, reloads. A programmatic reload
+ * revalidates index.html, which points at the new content-hashed assets — so the fresh bundle
+ * loads without a manual hard-refresh.
+ *
+ * Reloading is idle-safe: it waits until the player isn't typing and isn't in combat, and
+ * meanwhile shows a dismissable "new version" banner they can click to update right away.
+ */
+
+const POLL_MS = 3 * 60 * 1000; // how often to check for a new build
+const IDLE_MS = 15 * 1000; // "idle" = no user input for at least this long
+const SAFE_RETRY_MS = 5 * 1000; // re-check safety this often while a reload is pending
+const RELOADED_KEY = 'mudjs.reloadedForBuild';
+
+let lastInputAt = Date.now();
+let pendingBuild = null; // the newer build we intend to reload into
+let bannerShown = false;
+
+function markInput() {
+  lastInputAt = Date.now();
+}
+
+// webPrompt sends prompt.fight (>0 while fighting); prompt.js mirrors it onto window.mudprompt.
+function inCombat() {
+  return !!(window.mudprompt && window.mudprompt.fight > 0);
+}
+
+function isSafeToReload() {
+  return Date.now() - lastInputAt > IDLE_MS && !inCombat();
+}
+
+function reload(target) {
+  // Loop guard: if we already reloaded for this build and we're still on the old one, the
+  // served bundle hasn't caught up (deploy/cache lag) — stop auto-reloading, keep the banner.
+  try {
+    if (sessionStorage.getItem(RELOADED_KEY) === target) return;
+    sessionStorage.setItem(RELOADED_KEY, target);
+  } catch (e) {
+    /* sessionStorage may be unavailable (private mode) — reload anyway */
+  }
+  window.location.reload();
+}
+
+function reloadWhenSafe(target) {
+  if (pendingBuild !== target) return; // superseded by an even newer build
+  if (isSafeToReload()) {
+    reload(target);
+    return;
+  }
+  setTimeout(() => reloadWhenSafe(target), SAFE_RETRY_MS);
+}
+
+function showBanner(target) {
+  if (bannerShown) return;
+  bannerShown = true;
+  const el = document.createElement('div');
+  el.className = 'mudjs-update-banner';
+  el.setAttribute('role', 'button');
+  el.tabIndex = 0;
+  el.textContent = 'Доступна новая версия клиента — нажми, чтобы обновить.';
+  el.style.cssText =
+    'position:fixed;left:0;right:0;bottom:0;z-index:99998;padding:8px 14px;' +
+    'text-align:center;cursor:pointer;background:#1e1e1e;color:#BB86FC;' +
+    'border-top:1px solid #BB86FC;font:13px/1.4 sans-serif';
+  el.addEventListener('click', () => reload(target));
+  el.addEventListener('keydown', e => {
+    if (e.key === 'Enter' || e.key === ' ') reload(target);
+  });
+  (document.body || document.documentElement).appendChild(el);
+}
+
+function onNewBuild(target) {
+  pendingBuild = target;
+  showBanner(target); // immediate, dismissable affordance
+  reloadWhenSafe(target); // auto-reload once the player is idle & out of combat
+}
+
+async function checkVersion() {
+  try {
+    const url = (import.meta.env.BASE_URL || '/') + 'version.json';
+    const res = await fetch(url, { cache: 'no-store' });
+    if (!res.ok) return;
+    const data = await res.json();
+    if (data && data.build && data.build !== __BUILD_ID__ && data.build !== pendingBuild) {
+      onNewBuild(data.build);
+    }
+  } catch (e) {
+    /* offline / transient — ignore and try again next tick */
+  }
+}
+
+export function startAutoUpdate() {
+  ['mousedown', 'keydown', 'input', 'touchstart', 'wheel'].forEach(ev =>
+    document.addEventListener(ev, markInput, { passive: true, capture: true })
+  );
+  // A refocused tab is a natural moment to catch up on a deploy that happened while away.
+  document.addEventListener('visibilitychange', () => {
+    if (!document.hidden) checkVersion();
+  });
+  setInterval(checkVersion, POLL_MS);
+}

--- a/src/components/mapper/useGraphMapper.js
+++ b/src/components/mapper/useGraphMapper.js
@@ -10,7 +10,7 @@
  * Graph JSON is fetched on demand from /maps/graph/ (served beside the legacy ASCII
  * /maps/sources/*.html), mirroring how the ASCII map already fetches per-area.
  */
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { findPath, pathToSpeedwalk } from './pathfinding.js';
 import { DIR_LETTERS } from './types.js';
 import { t } from './i18n.js';
@@ -18,6 +18,10 @@ import { resolveLayoutFlexer } from './flexer.js';
 import { send } from '../../websock.js';
 
 const GRAPH_BASE = '/maps/graph';
+
+// How often to re-pull the current area's graph in the background, so a server-side regen
+// shows up without the player re-entering the area (or hard-refreshing the client).
+const AREA_REFRESH_MS = 5 * 60 * 1000;
 
 /** Live area filename ("newthalos.are") -> mapper graph key ("newthalos"). */
 export function areaKey(area) {
@@ -103,6 +107,10 @@ export function useGraphMapper(location, enabled) {
     return () => { cancelled = true; };
   }, [enabled, index]);
 
+  // Raw graph bytes of the loaded area, so the background refresh below can tell whether a
+  // re-fetch actually changed anything and skip a needless re-render when it didn't.
+  const rawTextRef = useRef(null);
+
   // Load the player's area graph whenever the area changes (and the graph view is active).
   useEffect(() => {
     if (!enabled || !areaFile) return;
@@ -112,21 +120,53 @@ export function useGraphMapper(location, enabled) {
       .then((r) => {
         if (r.status === 404) throw new Error('missing');
         if (!r.ok) throw new Error('http ' + r.status);
-        return r.json();
+        return r.text();
       })
-      .then((l) => {
+      .then((text) => {
         if (cancelled) return;
+        rawTextRef.current = text;
+        const l = JSON.parse(text);
         rebaseZ(l); // ground layer -> z=0 before choosing the active layer
         setRawLayout(l);
         setStatus('ready');
       })
       .catch((err) => {
         if (cancelled) return;
+        rawTextRef.current = null;
         setRawLayout(null);
         setStatus(err.message === 'missing' ? 'missing' : 'error');
         if (err.message !== 'missing') console.warn('[mapper] area load failed', areaFile, err);
       });
     return () => { cancelled = true; };
+  }, [enabled, areaFile]);
+
+  // Background refresh: re-pull the current area's graph on an interval and whenever the tab
+  // regains focus, so a server-side regen appears without re-entering the area. It never flips
+  // `status` (no loading flicker) and only swaps the layout in when the bytes actually change.
+  useEffect(() => {
+    if (!enabled || !areaFile) return;
+    let cancelled = false;
+    const refresh = () => {
+      fetch(`${GRAPH_BASE}/area-${areaFile}.json`, { cache: 'no-cache' })
+        .then((r) => (r.ok ? r.text() : Promise.reject(new Error('http ' + r.status))))
+        .then((text) => {
+          if (cancelled || text === rawTextRef.current) return; // unchanged -> no re-render
+          rawTextRef.current = text;
+          const l = JSON.parse(text);
+          rebaseZ(l);
+          setRawLayout(l);
+          setStatus('ready'); // also recover if the area only just gained a graph
+        })
+        .catch(() => {}); // transient/missing -> keep what we have
+    };
+    const id = setInterval(refresh, AREA_REFRESH_MS);
+    const onVisible = () => { if (!document.hidden) refresh(); };
+    document.addEventListener('visibilitychange', onVisible);
+    return () => {
+      cancelled = true;
+      clearInterval(id);
+      document.removeEventListener('visibilitychange', onVisible);
+    };
   }, [enabled, areaFile]);
 
   // Follow the player: on area-load and on every move, refocus the panel + active layer

--- a/src/main.js
+++ b/src/main.js
@@ -4,6 +4,7 @@ import { connect } from './websock';
 import lastLocation from './location';
 import getSessionId from './sessionid.js';
 import historydb from './historydb';
+import { startAutoUpdate } from './autoupdate';
 
 import './notify';
 import './input';
@@ -86,6 +87,7 @@ $(document).ready(function () {
 
   connect();
   initTerminalFontSize();
+  startAutoUpdate();
 
   /*
    * Handlers for plus-minus buttons to change terminal font size.

--- a/vite.config.js
+++ b/vite.config.js
@@ -27,8 +27,29 @@ function devMapperGraph() {
   };
 }
 
+// Per-build identifier the running client polls (version.json) to detect a new deploy and
+// self-update (see src/autoupdate.js). A timestamp guarantees it changes on every build.
+const BUILD_ID = String(Date.now());
+
+/** Emit build/version.json carrying BUILD_ID, served beside the bundle for the update poll. */
+function emitVersion() {
+  return {
+    name: 'dl-emit-version',
+    generateBundle() {
+      this.emitFile({
+        type: 'asset',
+        fileName: 'version.json',
+        source: JSON.stringify({ build: BUILD_ID }),
+      });
+    },
+  };
+}
+
 export default defineConfig({
-  plugins: [react(), devMapperGraph()],
+  plugins: [react(), devMapperGraph(), emitVersion()],
+  define: {
+    __BUILD_ID__: JSON.stringify(BUILD_ID),
+  },
   base: '/mudjs/', // 👈 путь, с которого будет искаться index.html и ассеты
   build: {
     // nginx serves /var/www/mudjs/build; vite defaults to dist/, so pin it to build/


### PR DESCRIPTION
Players had to **hard-refresh** to see a new deploy. Root cause: nginx serves `/mudjs/index.html` with no `Cache-Control`, so the browser keeps the cached HTML — and with it the old content-hashed asset references — until a hard refresh.

### What this does (client-only — no nginx change required)
- Each build stamps a `BUILD_ID` into the bundle (`__BUILD_ID__`) and a sibling **`version.json`** (`vite.config.js`).
- **`src/autoupdate.js`** polls `version.json` (with `no-store`, so the poll itself is never cached) every ~3 min and on tab refocus. On a newer build it reloads. A *programmatic* `location.reload()` revalidates `index.html`, so the fresh bundle loads **without a hard-refresh** — and without depending on any nginx change.
- The reload is **idle-safe**: it waits until the player isn't typing and isn't in combat (`window.mudprompt.fight`), and meanwhile shows a dismissable banner they can click to update right away. A `sessionStorage` guard prevents reload loops if a deploy lags.
- **`useGraphMapper`** now re-pulls the current area's graph in the background (interval + tab refocus) and swaps it in only when the bytes actually change — so a server-side graph regen appears **without re-entering the area**.

A matching nginx tweak (no-cache on the `/mudjs` html, shorter cache on `/maps/graph`) will follow to make plain manual refreshes always-fresh too, but isn't required for the above to work.