### PR TITLE
web client: raise extra-descr read= keyword cap to 200 chars

### DIFF
--- a/src/manip.js
+++ b/src/manip.js
@@ -77,7 +77,7 @@ function manipParseAndReplace(span) {
   // Replace extra-description placeholders [read=sign знак,see=sign] with (<span class="manip-cmd manip-ed" data-action="read 'sign знак'">sign</span>).
   // Returns empty string if 'see' part is not contained within 'read' part.
   html = html.replace(
-    /\[read=([^,]{1,100}),see=([^\]]{1,30})]/gi,
+    /\[read=([^,]{1,200}),see=([^\]]{1,30})]/gi,
     function (match, p1, p2, string) {
       if (p1.toLowerCase().split(' ').indexOf(p2.toLowerCase()) === -1)
         return '';


### PR DESCRIPTION
## Problem

The `[read=...,see=...]` pseudo-tag regex in `manip.js` caps the `read=` keyword id at 100 chars:

```js
/\[read=([^,]{1,100}),see=([^\]]{1,30})]/gi
```

The server sends the matched extra-description's **full keyword list** as the `read=` id. Multilingual (EN+RU+UA) lists can exceed 100 chars — e.g. Haon Dor room 6120's `(banks)` ED is 106 chars. When the id is too long the regex fails to match the tag and the raw `[read=...,see=banks]` text leaks straight into the room description (the reported glitch).

A scan of all area files found **12 extra descriptions** over 100 chars (longest 112), so this is a game-wide latent bug, not a single room.

## Fix

Raise the `read=` cap from 100 to 200. `[^,]` is already anchored by the `,see=` boundary (keyword lists contain no commas), so the larger bound is safe — no cross-tag overmatch or backtracking risk. `see=` stays at 30 (always a single short word). No area data touched.

## Verify

Hard-refresh the web client, `look` in room 6120 (Haon Dor riverbank), click `(banks)` — the link renders instead of leaking the raw tag.