### PR TITLE
web client: raise cmd= tag arg cap to 200 chars

### DIFF
--- a/src/manip.js
+++ b/src/manip.js
@@ -95,7 +95,7 @@ function manipParseAndReplace(span) {
 
   // Replace random commands with data-action span.
   html = html.replace(
-    /\[cmd=([^,]{1,70}),see=([^\]]{1,50}),nonce=(.{8})]/gi,
+    /\[cmd=([^,]{1,200}),see=([^\]]{1,50}),nonce=(.{8})]/gi,
     function (match, cmd, see, nonce, string) {
       // Ensure the command is coming from the server.
       if (nonce !== ws?.nonce) {


### PR DESCRIPTION
## Problem

The `[cmd=...,see=...,nonce=...]` pseudo-tag regex in `manip.js` caps the command argument at 70 chars:

```js
/\[cmd=([^,]{1,70}),see=([^\]]{1,50}),nonce=(.{8})]/gi
```

Server-side `cmd=` buttons can carry arguments longer than 70:

- **OLC extra-descr edit button** emits `ed web <keyword>` (`redit.cpp:293-295`, `oedit.cpp:279-281`). A multilingual (EN+RU+UA) keyword list of 100+ chars pushes the cmd to 113+ chars, so the regex fails and the raw `[cmd=ed web ...,see=edit,nonce=...]` tag leaks straight into the OLC screen.
- **Confirm reject button** emits `confirm reject <name> Прочти 'справка описание'` (`confirm.cpp:386`), which grows with the player name length.

Both are the same family as the `read=` keyword-cap bug (PR #121): a web-manip pseudo-tag regex cap that's too small for long arguments.

## Fix

Raise the `cmd=` cap from 70 to 200 (matching `read=`). `[^,]` is already anchored by the `,see=` boundary (these commands contain no commas), so the larger bound is safe. `see=` stays at 50 (always a short label like `edit` / `Отклонить`).

## Verify

- In OLC, `redit`/`oedit` a room/object with a 100+ char extra-descr keyword list → the `edit` button renders instead of leaking the raw `[cmd=...]` tag.
- The `[Отклонить]` confirm-reject button works for long player names.