### PR TITLE
Fix #hotkey for Cyrillic keys; fix #help delete typo

### DIFF
--- a/src/components/sysCommands/delete.js
+++ b/src/components/sysCommands/delete.js
@@ -7,7 +7,7 @@ export const deleteHelp = {
 #delete                 - вывести список хранилищ доступных для взаимодействия
 #delete storage         - вывести список записей из storage, которые можно удалить
 #delete storage record  - удалить запись record из хранилища storage
-#delete storage all     - ключевое своло all позволяет удалить все записи из хранилища storage 
+#delete storage all     - ключевое слово all позволяет удалить все записи из хранилища storage
 
 `
 }

--- a/src/components/sysCommands/hotkey.js
+++ b/src/components/sysCommands/hotkey.js
@@ -37,8 +37,24 @@ export const hotkeyHelp = {
 
 const errHotkey = `Набери ${clickableLink('#help hotkey')} для справки.\n`;
 
+// Normalize any key spelling to the canonical name a keypress produces
+// (keycode.names[keycode(...)]), so "#hotkey я" and "#hotkey z" -- and their
+// ctrl/alt/shift combos -- all resolve to the same stored key. Falls back to the
+// raw (lowercased) string when the key can't be resolved, which keeps prefix
+// lookups like "#hotkey kp" working.
+const canonicalKey = rawKey => {
+  const key = String(rawKey).toLowerCase().replace(/\s/g, '');
+  const combo = key.match(/^(ctrl|alt|shift)\+(.+)$/);
+  if (combo) {
+    const name = keycode.names[keycode(combo[2])];
+    return name ? `${combo[1]}+${name}` : key;
+  }
+  const name = keycode.names[keycode(key)];
+  return name || key;
+};
+
 const checkKey = rawKey => {
-  let key = rawKey.toLowerCase().replace(/\s/g, '');
+  let key = canonicalKey(rawKey);
   let err = '';
 
   let combos = key.match(/^(ctrl|alt|shift)\+(.+)$/);
@@ -54,7 +70,8 @@ const checkKey = rawKey => {
   return { key, err };
 };
 
-const hotkeyCmdDelete = key => {
+const hotkeyCmdDelete = rawKey => {
+  const key = canonicalKey(rawKey);
   const hotkeyStorage = localStorage.hotkey
     ? JSON.parse(localStorage.hotkey)
     : {};
@@ -68,7 +85,8 @@ const hotkeyCmdDelete = key => {
   return echoHtml(`Такая горячая клавиша не задана.\n`);
 };
 
-const hotkeyCmdShow = key => {
+const hotkeyCmdShow = rawKey => {
+  const key = canonicalKey(rawKey);
   const hotkeyStorage = localStorage.hotkey
     ? JSON.parse(localStorage.hotkey)
     : {};

--- a/src/components/sysCommands/keycode.js
+++ b/src/components/sysCommands/keycode.js
@@ -110,4 +110,24 @@ for (let alias in keyCode.aliases) {
   keyCode.codes[alias] = keyCode.aliases[alias];
 }
 
+// Cyrillic (ЙЦУКЕН, RU + UK) letters share physical keys with QWERTY. The
+// browser reports e.which by physical key, so pressing я yields 90 (the Z key).
+// Map each Cyrillic letter to the code of the Latin key it sits on, so that
+// "#hotkey я" binds the same physical key the keypress reports. Added AFTER the
+// reverse map on purpose, so names[] keeps the Latin label (e.g. 90 -> "z").
+const cyrillicLayout = {
+  // top row
+  й: 'q', ц: 'w', у: 'e', к: 'r', е: 't', н: 'y', г: 'u', ш: 'i', щ: 'o', з: 'p', х: '[', ъ: ']', ї: ']',
+  // home row
+  ф: 'a', ы: 's', і: 's', в: 'd', а: 'f', п: 'g', р: 'h', о: 'j', л: 'k', д: 'l', ж: ';', э: "'", є: "'",
+  // bottom row
+  я: 'z', ч: 'x', с: 'c', м: 'v', и: 'b', т: 'n', ь: 'm', б: ',', ю: '.',
+  // extras: ё on backtick, UK ґ on backslash
+  ё: '`', ґ: '\\',
+};
+for (let cyr in cyrillicLayout) {
+  const code = keyCode.codes[cyrillicLayout[cyr]];
+  if (code !== undefined) keyCode.codes[cyr] = code;
+}
+
 export default keyCode;


### PR DESCRIPTION
Two in-client bug reports.

**`#hotkey я` never worked** (`#hotkey z` did): the binding was stored under the raw string "я", but a keypress reports `e.which` by *physical* key — я sits on the Z key → which 90 — so the runtime looked up "z" and missed. Latin keys worked only because their raw spelling already matched the physical-key name.
- `keycode.js`: map each Cyrillic (ЙЦУКЕН, RU + UK) letter to the code of the Latin key it shares, so `keyCode("я") === 90`. Added after the reverse map so `names[]` keeps the Latin label (90 → "z").
- `hotkey.js`: canonicalize keys (and ctrl/alt/shift combos) to the press-time name before store/lookup, so `#hotkey я` and `#hotkey z` land on the same binding. Latin/named keys unaffected; bind/delete/show all go through it.

**Typo:** `#help delete` — "ключевое **своло** all" → "ключевое **слово** all".

Test: `#hotkey я север`, then press я on a RU/UK layout → goes north. Hard-refresh to bust cache after deploy.