### PR TITLE
Localize the graph map by config language

### DIFF
--- a/src/components/map.jsx
+++ b/src/components/map.jsx
@@ -9,7 +9,7 @@ import lastLocation from '../location';
 import { Search } from './mapper/Search';
 import GraphMapPane from './mapper/GraphMapPane';
 import { useGraphMapper } from './mapper/useGraphMapper';
-import { t } from './mapper/i18n.js';
+import { t, setLocale, localeFromLang, nameFor } from './mapper/i18n.js';
 import './mapper/mapper.css';
 
 const useLocation = () => {
@@ -29,7 +29,8 @@ const useLocation = () => {
             prev &&
             prev.area === next.area &&
             prev.vnum === next.vnum &&
-            prev.sex === next.sex
+            prev.sex === next.sex &&
+            prev.lang === next.lang
               ? prev
               : next
           );
@@ -211,13 +212,28 @@ const LayerSelect = ({ layout, zFilter, onChange }) => {
 export default function Map() {
   const location = useLocation();
   const areaData = useAreaData();
-  const areaName = areaData[location.area || ''] || '';
+
+  // Follow the player's in-game `config language`: point the mapper's shared string
+  // table + name-picker at the matching locale before any child renders. setLocale is a
+  // no-op when unchanged; the top-of-tree call means the fresh `t`/`locale`/`nameFor`
+  // are already live when GraphMapPane/Map/Search (below) read them this render. The
+  // `locale` prop threaded to the memoized children is what actually re-triggers their
+  // render on a pure language switch (no area/vnum change to bust their memo otherwise).
+  const locale = localeFromLang(location.lang);
+  setLocale(locale);
 
   // 'graph' = new DL mapper (default); 'ascii' = legacy HTML map. Persisted per-browser.
   const [mode, setMode] = useState(() => localStorage.getItem('map-mode') || 'graph');
   const [drawerOpen, setDrawerOpen] = useState(false);
 
   const graph = useGraphMapper(location, mode === 'graph');
+
+  // Prefer the graph's own area meta (carries the en/ua i18n block) for the topbar name;
+  // fall back to the legacy /maps/index.json name (RU only) in ASCII mode / ungraphed zones.
+  const areaName =
+    (graph.layout?.meta ? nameFor(graph.layout.meta, locale) : '') ||
+    areaData[location.area || ''] ||
+    '';
 
   const setModePersisted = useCallback(next => {
     setMode(next);
@@ -283,7 +299,7 @@ export default function Map() {
 
           {graphReady && (
             <>
-              <Search layout={graph.layout} onPick={handleSelectRoom} />
+              <Search layout={graph.layout} locale={locale} onPick={handleSelectRoom} />
               <LayerSelect
                 layout={graph.layout}
                 zFilter={graph.zFilter}
@@ -326,6 +342,7 @@ export default function Map() {
       ) : (
         <GraphMapPane
           zoomApiRef={zoomApiRef}
+          locale={locale}
           index={graph.index}
           layout={graph.layout}
           status={graph.status}

--- a/src/components/mapper/GraphMapPane.jsx
+++ b/src/components/mapper/GraphMapPane.jsx
@@ -13,6 +13,7 @@ import { t } from './i18n.js';
 
 function GraphMapPane({
   zoomApiRef,
+  locale,
   index,
   layout,
   status,
@@ -60,6 +61,7 @@ function GraphMapPane({
       <GraphMap
         layout={layout}
         index={index}
+        locale={locale}
         currentVnum={currentVnum}
         selectedVnum={selectedVnum}
         activeZ={activeZ}
@@ -76,6 +78,7 @@ function GraphMapPane({
           <SidePanel
             layout={layout}
             index={index}
+            locale={locale}
             vnum={selectedVnum}
             currentVnum={currentVnum}
             onClose={onCloseDrawer}

--- a/src/components/mapper/Map.tsx
+++ b/src/components/mapper/Map.tsx
@@ -4,7 +4,7 @@ import { zoom, zoomIdentity, type ZoomBehavior } from 'd3-zoom';
 import type { AreaLayout, Direction, ExitStyle, MapperIndex, PlacedExit, PlacedRoom } from './types.js';
 import { DIR_DELTAS, REVERSE_DIR } from './types.js';
 import { sectorStyle, sectorLabel } from './sectors.js';
-import { t } from './i18n.js';
+import { t, nameFor, type Locale } from './i18n.js';
 
 /* ---- visual scale ---- */
 const TILE_W = 124;
@@ -26,6 +26,10 @@ const STUB_LEN = 40;
 interface Props {
   layout: AreaLayout;
   index: MapperIndex;
+  /** Active display locale (from the player's `config language`). Drives room/area name
+   *  selection via nameFor(); also the prop that re-renders this memoized Map on a pure
+   *  language switch (no layout/vnum change would otherwise bust the memo). */
+  locale: Locale;
   currentVnum: number | null;
   selectedVnum: number | null;
   activeZ: number;
@@ -365,7 +369,7 @@ function cardinalArc(
   return `M${sxp},${syp} Q${ctrlX},${ctrlY} ${txp},${typ}`;
 }
 
-export const Map = memo(function Map({ layout, index, currentVnum, selectedVnum, activeZ, onSelectRoom, onSetCurrent, onCrossArea, onChangeZ, zFilter, zoomApiRef }: Props) {
+export const Map = memo(function Map({ layout, index, locale, currentVnum, selectedVnum, activeZ, onSelectRoom, onSetCurrent, onCrossArea, onChangeZ, zFilter, zoomApiRef }: Props) {
   const svgRef = useRef<SVGSVGElement>(null);
   const gRef = useRef<SVGGElement>(null);
   const zoomRef = useRef<ZoomBehavior<SVGSVGElement, unknown> | null>(null);
@@ -394,9 +398,9 @@ export const Map = memo(function Map({ layout, index, currentVnum, selectedVnum,
   // component is named `Map`, which shadows the global Map constructor in this module.
   const areaNameByFile = useMemo(() => {
     const m: Record<string, string> = {};
-    for (const a of index.areas) m[a.file] = a.name;
+    for (const a of index.areas) m[a.file] = nameFor(a, locale);
     return m;
-  }, [index]);
+  }, [index, locale]);
 
   const visibleEdges = useMemo(() => {
     return layout.exits.filter((e) => {
@@ -504,7 +508,7 @@ export const Map = memo(function Map({ layout, index, currentVnum, selectedVnum,
   const labelZoom = Math.min(2.4, Math.max(1, 1 / transform.k));
 
   return (
-    <svg ref={svgRef} className="map-svg" role="group" aria-label={t.mapOf(layout.meta.name)}>
+    <svg ref={svgRef} className="map-svg" role="group" aria-label={t.mapOf(nameFor(layout.meta, locale))}>
       <defs>
         {/* Soft drop shadow filter — replaces the manual offset rect for a more painterly look. */}
         <filter id="tile-shadow" x="-30%" y="-30%" width="160%" height="160%">
@@ -756,6 +760,7 @@ export const Map = memo(function Map({ layout, index, currentVnum, selectedVnum,
         {visibleRooms.map((p) => {
           const room = layout.rooms[p.vnum];
           if (!room) return null;
+          const roomName = nameFor(room, locale);
           const { sx, sy } = placedToScreen(p, layout.bounds);
           // 'indoors'-flagged rooms render like the 'inside' sector.
           const effectiveSector = room.flags.includes('indoors') ? 'inside' : room.sector;
@@ -774,7 +779,7 @@ export const Map = memo(function Map({ layout, index, currentVnum, selectedVnum,
           const hasNeighborY = occupied.has(`${p.x},${p.y - 1},${p.z}`) || occupied.has(`${p.x},${p.y + 1},${p.z}`);
           const maxW = hasNeighborX ? TILE_W - 8 : TILE_W + GAP_X * 0.8;
           const maxH = hasNeighborY ? TILE_H - 6 : TILE_H + GAP_Y * 0.8;
-          const base = boxedLabel(room.name, maxW, maxH, 22);
+          const base = boxedLabel(roomName, maxW, maxH, 22);
           const bw = base.lines.reduce((m, l) => Math.max(m, l.length), 0) * base.fontSize * 0.6;
           const bh = base.lines.length * base.fontSize * 1.15;
           const growCap = Math.max(1, Math.min(maxW / (bw || 1), maxH / (bh || 1)));
@@ -813,7 +818,7 @@ export const Map = memo(function Map({ layout, index, currentVnum, selectedVnum,
                transform={`translate(${cx} ${cy}) scale(${scale}) translate(${-cx} ${-cy})`}
                role="button"
                tabIndex={0}
-               aria-label={`${room.name || t.unnamedRoom}, ${sectorLabel(effectiveSector)}${p.z !== 0 ? t.layerZ(p.z) : ''}${isCurrent ? ', ' + t.currentLocation : ''}`}
+               aria-label={`${roomName || t.unnamedRoom}, ${sectorLabel(effectiveSector)}${p.z !== 0 ? t.layerZ(p.z) : ''}${isCurrent ? ', ' + t.currentLocation : ''}`}
                style={{ cursor: 'pointer' }}
                onClick={() => onSelectRoom(p.vnum)}
                onDoubleClick={() => onSetCurrent(p.vnum)}>
@@ -854,7 +859,7 @@ export const Map = memo(function Map({ layout, index, currentVnum, selectedVnum,
                 </>
               )}
 
-              <title>{`${room.name || t.unnamedRoom}\n${sectorLabel(room.sector)}\n${t.exits}: ${room.exits.map((e) => t.dir[e.dir] ?? e.dir).join(', ') || '—'}`}</title>
+              <title>{`${roomName || t.unnamedRoom}\n${sectorLabel(room.sector)}\n${t.exits}: ${room.exits.map((e) => t.dir[e.dir] ?? e.dir).join(', ') || '—'}`}</title>
             </g>
           );
         })}
@@ -921,7 +926,9 @@ function renderVerticalStub(
 
   const otherP = layout.placed[otherVnum];
   const otherRoom = layout.rooms[otherVnum];
-  const targetName = otherRoom?.name || '(unknown)';
+  // Module helper (no locale param): nameFor() defaults to the active locale, which the
+  // top-of-tree setLocale() has already pointed at the player's language this render.
+  const targetName = nameFor(otherRoom) || '(unknown)';
   const targetZ = otherP?.z ?? anchorP.z;
 
   const { sx, sy } = placedToScreen(anchorP, layout.bounds);

--- a/src/components/mapper/Search.tsx
+++ b/src/components/mapper/Search.tsx
@@ -1,21 +1,23 @@
 import { useEffect, useMemo, useState } from 'react';
 import Fuse from 'fuse.js';
 import type { AreaLayout } from './types.js';
-import { t } from './i18n.js';
+import { t, nameFor, type Locale } from './i18n.js';
 
 interface Props {
   layout: AreaLayout;
+  /** Active display locale — search matches + result labels use the localized room name. */
+  locale: Locale;
   onPick: (vnum: number) => void;
 }
 
-export function Search({ layout, onPick }: Props) {
+export function Search({ layout, locale, onPick }: Props) {
   const [query, setQuery] = useState('');
   const [open, setOpen] = useState(false);
 
   const fuse = useMemo(() => {
     const items = Object.values(layout.rooms).map((r) => ({
       vnum: r.vnum,
-      name: r.name,
+      name: nameFor(r, locale),
     }));
     return new Fuse(items, {
       keys: ['name'],
@@ -23,7 +25,7 @@ export function Search({ layout, onPick }: Props) {
       minMatchCharLength: 2,
       ignoreLocation: true,
     });
-  }, [layout]);
+  }, [layout, locale]);
 
   const results = useMemo(() => {
     const q = query.trim().toLowerCase();
@@ -31,8 +33,10 @@ export function Search({ layout, onPick }: Props) {
     // Substring-first: an exact case-insensitive contains is what players expect
     // ("спа" -> "Небольшая Спальня"), ranked by match position then shorter name.
     // Plain fuzzy (Fuse) wrongly surfaced unrelated rooms like "Край Леса" for "спа".
+    // Names resolve through nameFor() so search follows the player's config language.
     const subs = Object.values(layout.rooms)
-      .filter((r) => (r.name || '').toLowerCase().includes(q))
+      .map((r) => ({ vnum: r.vnum, name: nameFor(r, locale) }))
+      .filter((r) => r.name.toLowerCase().includes(q))
       .sort((a, b) => {
         const ia = a.name.toLowerCase().indexOf(q);
         const ib = b.name.toLowerCase().indexOf(q);
@@ -42,7 +46,7 @@ export function Search({ layout, onPick }: Props) {
     if (subs.length > 0) return subs.slice(0, 8);
     // Fall back to fuzzy only when nothing contains the query (typo tolerance).
     return fuse.search(query).slice(0, 8);
-  }, [query, fuse, layout]);
+  }, [query, fuse, layout, locale]);
 
   useEffect(() => { setOpen(query.length >= 2 && results.length > 0); }, [query, results]);
 

--- a/src/components/mapper/SidePanel.tsx
+++ b/src/components/mapper/SidePanel.tsx
@@ -1,10 +1,12 @@
 import type { AreaLayout, MapperIndex } from './types.js';
 import { sectorLabel, sectorStyle } from './sectors.js';
-import { t } from './i18n.js';
+import { t, nameFor, descFor, type Locale } from './i18n.js';
 
 interface Props {
   layout: AreaLayout;
   index: MapperIndex;
+  /** Active display locale (player's `config language`) for room/zone names + description. */
+  locale: Locale;
   vnum: number | null;
   currentVnum: number | null;
   onSetCurrent: (vnum: number) => void;
@@ -25,7 +27,7 @@ function exitEmoji(flags: string[], targetSector?: string): string {
   return '';
 }
 
-export function SidePanel({ layout, index, vnum, currentVnum, onSetCurrent, onRunTo, onClose, onWalk }: Props) {
+export function SidePanel({ layout, index, locale, vnum, currentVnum, onSetCurrent, onRunTo, onClose, onWalk }: Props) {
   if (vnum == null) {
     return (
       <div className="panel">
@@ -42,7 +44,7 @@ export function SidePanel({ layout, index, vnum, currentVnum, onSetCurrent, onRu
   return (
     <div className="panel">
       <div className="panel-head">
-        <h2 className="panel-title">{room.name || t.unnamed}</h2>
+        <h2 className="panel-title">{nameFor(room, locale) || t.unnamed}</h2>
         <div className="panel-head-right">
           <span className="panel-meta">
             {sectorLabel(room.sector)} / {t.layer} {zText}
@@ -76,8 +78,9 @@ export function SidePanel({ layout, index, vnum, currentVnum, onSetCurrent, onRu
               const targetRoom = layout.rooms[ex.target];
               // Cross-area target: resolve the destination zone's localized name.
               const crossFile = targetRoom ? undefined : index.vnumToArea[ex.target];
-              const crossZone = crossFile ? index.areas.find((a) => a.file === crossFile)?.name : undefined;
-              const tgtName = targetRoom?.name || crossZone || t.anotherArea;
+              const crossArea = crossFile ? index.areas.find((a) => a.file === crossFile) : undefined;
+              const crossZone = crossArea ? nameFor(crossArea, locale) : undefined;
+              const tgtName = nameFor(targetRoom, locale) || crossZone || t.anotherArea;
               // Colour the destination by its sector (indoors → inside), matching the map tiles.
               const tgtColor = targetRoom
                 ? sectorStyle(targetRoom.flags.includes('indoors') ? 'inside' : targetRoom.sector).text
@@ -110,9 +113,9 @@ export function SidePanel({ layout, index, vnum, currentVnum, onSetCurrent, onRu
         )}
       </section>
 
-      {room.description && (
+      {descFor(room, locale) && (
         <section className="section">
-          <div className="description">{room.description}</div>
+          <div className="description">{descFor(room, locale)}</div>
         </section>
       )}
 

--- a/src/components/mapper/i18n.ts
+++ b/src/components/mapper/i18n.ts
@@ -1,13 +1,30 @@
 /**
- * UI string table. Default locale is Russian; a future player-settings toggle will
- * switch `locale` (and re-render). Room names themselves come from area data and are
- * already localized — this table is only the UI chrome and computed labels.
+ * UI string table. Default locale is Russian; the player's in-game `config language`
+ * drives `locale` via setLocale() (fed from the web-prompt `lang` field, see
+ * location.js). Room + area names come from the area data (graph JSON `i18n` block) —
+ * use nameFor()/descFor() to pick the display string for the active locale; this table
+ * is only the UI chrome and computed labels.
  */
 
-export type Locale = 'ru' | 'en';
+import type { LocalizedText } from './types.js';
+
+export type Locale = 'ru' | 'en' | 'ua';
+
+/** Anything carrying a base RU name/description plus optional en/ua overrides. */
+type Named = { name?: string; i18n?: LocalizedText };
+type Described = { description?: string; i18n?: LocalizedText };
 
 /** Russian plural picker: forms = [one, few, many] (1 шаг / 2 шага / 5 шагов). */
 function pluralRu(n: number, forms: [string, string, string]): string {
+  const n10 = n % 10;
+  const n100 = n % 100;
+  if (n10 === 1 && n100 !== 11) return forms[0];
+  if (n10 >= 2 && n10 <= 4 && (n100 < 10 || n100 >= 20)) return forms[1];
+  return forms[2];
+}
+
+/** Ukrainian plural picker: same one/few/many shape as Russian (1 крок / 2 кроки / 5 кроків). */
+function pluralUa(n: number, forms: [string, string, string]): string {
   const n10 = n % 10;
   const n100 = n % 100;
   if (n10 === 1 && n100 !== 11) return forms[0];
@@ -187,10 +204,105 @@ const en: Strings = {
   dirShort: { north: 'n', south: 's', east: 'e', west: 'w', up: 'u', down: 'd' },
 };
 
-const TABLE: Record<Locale, Strings> = { ru, en };
+const ua: Strings = {
+  area: 'Зона',
+  layer: 'шар',
+  testAreas: '— Тестові зони —',
+  allAreas: '— Усі зони —',
+  allLayers: 'усі',
+  selectArea: 'Обрати зону',
+  zLayerFilter: 'Фільтр за шаром',
+  viewMode: 'Режим відображення',
+  tabMap: 'Мапа',
+  tabList: 'Список',
+  loadingIndex: 'Завантаження індексу',
+  loadingArea: 'Завантаження зони',
+  noGraphMap: 'Графічної мапи для цієї зони поки немає.',
+  graphMapError: 'Не вдалося завантажити мапу зони.',
+  noAsciiMap: 'ASCII-мапи для цієї зони немає.',
+  showAscii: 'Показати ASCII-мапу',
+  closePanel: 'Закрити',
+  searchRooms: 'пошук кімнат…',
+  searchAria: 'Пошук кімнат у цій зоні',
+  resultsAria: 'Результати пошуку',
+  unnamed: '(без назви)',
+  clickRoom: 'Клікни кімнату, щоб оглянути її. Подвійний клік на будь-якій клітинці прокладе маршрут від твоєї поточної позиції.',
+  roomNotLoaded: 'Кімната не завантажена.',
+  flags: 'Прапори',
+  exits: 'Виходи',
+  description: 'Опис',
+  noExits: 'немає виходів',
+  anotherArea: '(інша зона)',
+  runHere: 'Бігти сюди',
+  unmapped: 'не на мапі',
+  voidHere: (reason) => `Жахлива порожнеча (${reason})`,
+  setCurrentFirst: 'Спершу вкажи поточну кімнату.',
+  alreadyThere: 'Уже тут.',
+  noPath: 'Немає шляху в межах зони.',
+  copied: 'скопійовано',
+  steps: (n) => `${n} ${pluralUa(n, ['крок', 'кроки', 'кроків'])}`,
+  mapOf: (name) => `Мапа зони ${name}`,
+  unnamedRoom: 'кімната без назви',
+  currentLocation: 'поточна позиція',
+  layerZ: (z) => `, шар z${zSign(z)}`,
+  upTo: (name) => `Вгору до ${name}`,
+  downTo: (name) => `Вниз до ${name}`,
+  toZone: (name) => `Перехід до зони ${name}`,
+  rooms: (n) => `${n} ${pluralUa(n, ['кімната', 'кімнати', 'кімнат'])}`,
+  clusters: (n) => `${n} ${pluralUa(n, ['кластер', 'кластери', 'кластерів'])}`,
+  layers: 'шари',
+  clusterOf: (i, total) => `Кластер ${i} з ${total}`,
+  layerHeading: (z, n) => `Шар z ${z} · ${n} ${pluralUa(n, ['кімната', 'кімнати', 'кімнат'])}`,
+  voidShort: '✦ порожнеча',
+  dir: { north: 'північ', south: 'південь', east: 'схід', west: 'захід', up: 'вгору', down: 'вниз' },
+  dirShort: { north: 'пн', south: 'пд', east: 'сх', west: 'зх', up: '^', down: 'v' },
+};
 
-/** Active locale. Default Russian; wire to player settings later. */
-export const locale: Locale = 'ru';
+const TABLE: Record<Locale, Strings> = { ru, en, ua };
 
-/** Active string table. */
-export const t: Strings = TABLE[locale];
+/**
+ * Active locale + string table. Mutable module state (live ES bindings): setLocale()
+ * swaps both, and every `import { t, locale }` sees the new value on its next read.
+ * Memoized components (GraphMapPane, Map) still need a `locale` prop to re-render on a
+ * pure language switch — the prop busts their memo; the render then reads the fresh `t`.
+ * Default RU keeps the map identical until the server sends a `lang` (pre-keystone).
+ */
+export let locale: Locale = 'ru';
+export let t: Strings = TABLE[locale];
+
+/** Point the UI at a locale. No-op if unchanged; unknown locales fall back to RU. */
+export function setLocale(loc: Locale): void {
+  const next: Locale = loc === 'en' || loc === 'ua' ? loc : 'ru';
+  if (next === locale) return;
+  locale = next;
+  t = TABLE[next];
+}
+
+/** Map the web-prompt `lang` attribute ("en"/"ru"/"ua") to a UI Locale; default RU. */
+export function localeFromLang(lang: string | undefined | null): Locale {
+  return lang === 'en' || lang === 'ua' ? lang : 'ru';
+}
+
+/**
+ * Display name for an entity (room / area meta) in `loc` (default: active locale).
+ * RU is the base `name`; en/ua come from the graph `i18n` block. Falls back to the RU
+ * base whenever the requested locale has no override (untranslated room, older graph).
+ */
+export function nameFor(entity: Named | null | undefined, loc: Locale = locale): string {
+  if (entity == null) return '';
+  if (loc !== 'ru' && entity.i18n) {
+    const over = entity.i18n[loc]?.name;
+    if (over != null && over !== '') return over;
+  }
+  return entity.name ?? '';
+}
+
+/** Display description for an entity in `loc` (default: active locale); RU base fallback. */
+export function descFor(entity: Described | null | undefined, loc: Locale = locale): string {
+  if (entity == null) return '';
+  if (loc !== 'ru' && entity.i18n) {
+    const over = entity.i18n[loc]?.description;
+    if (over != null && over !== '') return over;
+  }
+  return entity.description ?? '';
+}

--- a/src/components/mapper/sectors.ts
+++ b/src/components/mapper/sectors.ts
@@ -22,32 +22,35 @@ export interface SectorStyle {
   text: string;
   label: string;     // EN
   labelRu: string;   // RU
+  labelUa: string;   // UA
 }
 
 const STYLES: Record<string, SectorStyle> = {
-  inside:        { fill: '#2a2410', stroke: '#c4a000', text: '#d9b94a', label: 'Inside',       labelRu: 'Помещение'     }, // ansi yellow (interior)
-  city:          { fill: '#26282a', stroke: '#ffffff', text: '#ffffff', label: 'City',         labelRu: 'Город'         }, // white (paved)
-  field:         { fill: '#1c2a10', stroke: '#8ee34f', text: '#8ee34f', label: 'Field',        labelRu: 'Поле'          }, // ansi bright green (grass)
-  forest:        { fill: '#142509', stroke: '#4e9a06', text: '#6cba2e', label: 'Forest',       labelRu: 'Лес'           }, // ansi green (dense)
-  hills:         { fill: '#2a230f', stroke: '#c4a000', text: '#c4a000', label: 'Hills',        labelRu: 'Холмы'         }, // ansi dark yellow {y — brown
-  mountain:      { fill: '#232525', stroke: '#555753', text: '#a7aaa3', label: 'Mountain',     labelRu: 'Горы'          }, // ansi bright black (stone)
-  water_swim:    { fill: '#0f1f33', stroke: '#3465a4', text: '#55a3f2', label: 'Water (swim)', labelRu: 'Вода (вплавь)' }, // ansi blue
-  water_noswim:  { fill: '#0b1726', stroke: '#284a7e', text: '#4a86d8', label: 'Water (deep)', labelRu: 'Вода (глубоко)'}, // ansi blue (deep)
-  underwater:    { fill: '#07101d', stroke: '#3465a4', text: '#5a90d0', label: 'Underwater',   labelRu: 'Под водой'     }, // ansi blue (darkest)
-  air:           { fill: '#142632', stroke: '#55a3f2', text: '#7fc0ff', label: 'Air',          labelRu: 'Воздух'        }, // ansi bright blue (sky)
-  desert:        { fill: '#2c2810', stroke: '#fdea56', text: '#fdea56', label: 'Desert',       labelRu: 'Пустыня'       }, // ansi bright yellow (sand)
-  cave:          { fill: '#1a1c1d', stroke: '#555753', text: '#a7aaa3', label: 'Cave',         labelRu: 'Пещера'        }, // ansi bright black (dark)
-  jungle:        { fill: '#102414', stroke: '#06989a', text: '#45c9b0', label: 'Jungle',       labelRu: 'Джунгли'       }, // ansi cyan-green (humid)
-  tundra:        { fill: '#21282a', stroke: '#d3d7cf', text: '#e6e9e1', label: 'Tundra',       labelRu: 'Тундра'        }, // ansi white (snow)
-  unknown:       { fill: '#1a1a1a', stroke: '#555753', text: '#a7aaa3', label: 'Unknown',      labelRu: 'Неизвестно'    }, // terminal ground
+  inside:        { fill: '#2a2410', stroke: '#c4a000', text: '#d9b94a', label: 'Inside',       labelRu: 'Помещение',     labelUa: 'Приміщення'   }, // ansi yellow (interior)
+  city:          { fill: '#26282a', stroke: '#ffffff', text: '#ffffff', label: 'City',         labelRu: 'Город',         labelUa: 'Місто'        }, // white (paved)
+  field:         { fill: '#1c2a10', stroke: '#8ee34f', text: '#8ee34f', label: 'Field',        labelRu: 'Поле',          labelUa: 'Поле'         }, // ansi bright green (grass)
+  forest:        { fill: '#142509', stroke: '#4e9a06', text: '#6cba2e', label: 'Forest',       labelRu: 'Лес',           labelUa: 'Ліс'          }, // ansi green (dense)
+  hills:         { fill: '#2a230f', stroke: '#c4a000', text: '#c4a000', label: 'Hills',        labelRu: 'Холмы',         labelUa: 'Пагорби'      }, // ansi dark yellow {y — brown
+  mountain:      { fill: '#232525', stroke: '#555753', text: '#a7aaa3', label: 'Mountain',     labelRu: 'Горы',          labelUa: 'Гори'         }, // ansi bright black (stone)
+  water_swim:    { fill: '#0f1f33', stroke: '#3465a4', text: '#55a3f2', label: 'Water (swim)', labelRu: 'Вода (вплавь)', labelUa: 'Вода (вплав)' }, // ansi blue
+  water_noswim:  { fill: '#0b1726', stroke: '#284a7e', text: '#4a86d8', label: 'Water (deep)', labelRu: 'Вода (глубоко)',labelUa: 'Вода (глибоко)'}, // ansi blue (deep)
+  underwater:    { fill: '#07101d', stroke: '#3465a4', text: '#5a90d0', label: 'Underwater',   labelRu: 'Под водой',     labelUa: 'Під водою'    }, // ansi blue (darkest)
+  air:           { fill: '#142632', stroke: '#55a3f2', text: '#7fc0ff', label: 'Air',          labelRu: 'Воздух',        labelUa: 'Повітря'      }, // ansi bright blue (sky)
+  desert:        { fill: '#2c2810', stroke: '#fdea56', text: '#fdea56', label: 'Desert',       labelRu: 'Пустыня',       labelUa: 'Пустеля'      }, // ansi bright yellow (sand)
+  cave:          { fill: '#1a1c1d', stroke: '#555753', text: '#a7aaa3', label: 'Cave',         labelRu: 'Пещера',        labelUa: 'Печера'       }, // ansi bright black (dark)
+  jungle:        { fill: '#102414', stroke: '#06989a', text: '#45c9b0', label: 'Jungle',       labelRu: 'Джунгли',       labelUa: 'Джунглі'      }, // ansi cyan-green (humid)
+  tundra:        { fill: '#21282a', stroke: '#d3d7cf', text: '#e6e9e1', label: 'Tundra',       labelRu: 'Тундра',        labelUa: 'Тундра'       }, // ansi white (snow)
+  unknown:       { fill: '#1a1a1a', stroke: '#555753', text: '#a7aaa3', label: 'Unknown',      labelRu: 'Неизвестно',    labelUa: 'Невідомо'     }, // terminal ground
 };
 
 export function sectorStyle(sector: string): SectorStyle {
   return STYLES[sector] ?? STYLES.unknown;
 }
 
-/** Localized sector name for the active locale. */
+/** Localized sector name for the active locale (live `locale` binding from i18n). */
 export function sectorLabel(sector: string): string {
   const s = sectorStyle(sector);
-  return locale === 'ru' ? s.labelRu : s.label;
+  if (locale === 'ru') return s.labelRu;
+  if (locale === 'ua') return s.labelUa;
+  return s.label;
 }

--- a/src/components/mapper/types.ts
+++ b/src/components/mapper/types.ts
@@ -34,6 +34,19 @@ export type Sector =
   | 'water_swim' | 'water_noswim' | 'underwater' | 'air'
   | 'desert' | 'cave' | 'jungle' | 'tundra' | 'unknown';
 
+/**
+ * Per-language overrides for the non-default (non-RU) locales, mirrored from the
+ * dreamland_mapper graph output. The top-level `name`/`description` stay RU (the
+ * data-gen's base), and this block carries en/ua when the area XML has them so the
+ * web map can render room + area names in the viewer's config language. Absent for
+ * rooms with no en/ua text (older graphs, untranslated zones) — callers fall back
+ * to the RU `name`/`description`.
+ */
+export interface LocalizedText {
+  en?: { name?: string; description?: string };
+  ua?: { name?: string; description?: string };
+}
+
 export interface Exit {
   dir: Direction;
   target: number;
@@ -50,6 +63,7 @@ export interface Room {
   sector: Sector | string;
   flags: string[];       // 'dark', 'indoors', 'no_mob', etc.
   exits: Exit[];
+  i18n?: LocalizedText;  // en/ua name+description when present in the area XML
 }
 
 export interface AreaMeta {
@@ -63,6 +77,7 @@ export interface AreaMeta {
   flags: string[];       // 'hard', etc.
   speedwalk?: string;    // hint to entry path; first char often a vnum lookup
   altname?: string;
+  i18n?: LocalizedText;  // en/ua area name when present in the area XML
 }
 
 /* ---------- Layout output (post-BFS) ---------- */

--- a/src/location.js
+++ b/src/location.js
@@ -7,6 +7,10 @@ var lastLocation, locationChannel;
 // Remembered across prompts: the server may send the player's sex once (delta prompt), so
 // hold the last value seen and keep attaching it to every location broadcast.
 var lastSex;
+// Same delta-prompt treatment for the display language ("en"/"ru"/"ua"): the web prompt
+// carries it (interprethandler.cpp webPrompt -> Player::displayLang), and the map switches
+// its room/area names + UI chrome to it. Held so a `config language` change propagates.
+var lastLang;
 
 if ('BroadcastChannel' in window) {
   locationChannel = new BroadcastChannel('location');
@@ -64,10 +68,12 @@ function createPlaceholder(loc) {
 $(document).ready(function () {
   $('#rpc-events').on('rpc-prompt', function (e, b) {
     if (b.sex != null) lastSex = b.sex;
+    if (b.lang != null) lastLang = b.lang;
     var loc = {
       area: b.area,
       vnum: b.vnum,
       sex: lastSex,
+      lang: lastLang,
     };
     $('#input input').attr('placeholder', createPlaceholder(loc));
     bcastLocation(loc);


### PR DESCRIPTION
Render the web mapper's room names, area names, sector labels and UI chrome in the player's in-game `config language` (en/ru/ua) instead of Russian-only.

**How it follows the language**
- `location.js` attaches the web-prompt `lang` field (remembered across delta prompts, like `sex`) to every location broadcast.
- `i18n.ts` gains a Ukrainian UI string table + `'ua'` locale; `locale`/`t` become live module bindings driven by `setLocale()`; `nameFor()`/`descFor()` pick a room/area's en/ua override from the graph `i18n` block, falling back to the RU base.
- `map.jsx` sets the locale at the top of the render and threads a `locale` prop to the memoized children (GraphMapPane/Map) so a pure language switch re-renders them.
- `Map`/`SidePanel`/`Search` resolve names/descriptions via `nameFor`/`descFor` and re-key their memos on locale; `sectors.ts` gets Ukrainian labels.

**Backward compatible.** With no `lang` (pre-keystone) or no `i18n` in the served graph (pre-regen), it renders exactly as today. Pairs with the dreamland_code web-prompt `lang` field and dreamland_mapper's i18n graph output; the localized room/area *names* light up once the graph is regenerated with the new mapper.

Verified: `vite build` clean (1034 modules).