### PR TITLE
client i18n: central helper + trilingual widget chrome

### DIFF
--- a/src/components/cmdinput.jsx
+++ b/src/components/cmdinput.jsx
@@ -4,6 +4,7 @@ import $ from 'jquery';
 import { echo } from '../input';
 import { send, connect } from '../websock';
 import { getKeydown } from '../settings';
+import { t } from '../i18n';
 
 import useMediaQuery from '@mui/material/useMediaQuery';
 import { useTheme } from '@mui/material/styles';
@@ -40,6 +41,8 @@ const CmdInput = () => {
   const theme = useTheme();
   const big = useMediaQuery(theme.breakpoints.up('sm'));
   const connection = useSelector(state => state.connection);
+  // prompt is merged in the store, so lang stays stable -> re-renders only on a real switch.
+  const lang = useSelector(state => state.prompt && state.prompt.lang);
 
   const [value, setValue] = useState('');
   const textInput = useRef(null);
@@ -200,7 +203,7 @@ const CmdInput = () => {
   if (!connection.connected) {
     return (
       <button onClick={connect} type="button" className="btn btn-primary">
-        Reconnect
+        {t('in.reconnect', lang)}
       </button>
     );
   }
@@ -240,7 +243,7 @@ const CmdInput = () => {
               <td>
                 <button
                   onClick={historyRepeat}
-                  aria-label="Повторить команду"
+                  aria-label={t('in.repeat', lang)}
                   cmd="repeat"
                   className="btn btn-sm btn-ctrl btn-outline-primary"
                   style={{
@@ -255,7 +258,7 @@ const CmdInput = () => {
               <td>
                 <button
                   onClick={historyDown}
-                  aria-label="Следующая команда"
+                  aria-label={t('in.next', lang)}
                   cmd="history-down"
                   className="btn btn-sm btn-ctrl btn-outline-primary"
                   style={{
@@ -270,7 +273,7 @@ const CmdInput = () => {
               <td>
                 <button
                   onClick={historyUp}
-                  aria-label="Предыдущая команда"
+                  aria-label={t('in.prev', lang)}
                   cmd="history-up"
                   className="btn btn-sm btn-ctrl btn-outline-primary"
                   style={{

--- a/src/components/mainwindow.jsx
+++ b/src/components/mainwindow.jsx
@@ -1,4 +1,5 @@
 import React, { useState, useRef } from 'react';
+import { useSelector } from 'react-redux';
 import useMediaQuery from '@mui/material/useMediaQuery';
 import Box from '@mui/material/Box';
 import { useTheme } from '@mui/material/styles';
@@ -6,6 +7,7 @@ import CmdInput from './cmdinput';
 import Terminal from './terminal';
 
 import { send } from '../websock';
+import { t, fmt } from '../i18n';
 
 const OverlayCell = ({ ariaLabel, ariaHidden, children, ...props }) => {
   const theme = useTheme();
@@ -130,7 +132,7 @@ const Keypad = () => {
   );
 };
 
-const Overlay = ({ unread, onScrollToBottom }) => {
+const Overlay = ({ unread, onScrollToBottom, lang }) => {
   return (
     <Box
       sx={{
@@ -152,19 +154,19 @@ const Overlay = ({ unread, onScrollToBottom }) => {
       >
         <tbody>
           <tr>
-            <OverlayCell id="logs-button" ariaLabel="логи" ariaHidden="true">
+            <OverlayCell id="logs-button" ariaLabel={t('ov.logs', lang)} ariaHidden="true">
               <i className="fa fa-download"></i>
             </OverlayCell>
             <OverlayCell
               id="settings-button"
               data-toggle="modal"
               data-target="#settings-modal"
-              ariaLabel="настройки"
+              ariaLabel={t('ov.settings', lang)}
               ariaHidden="false"
             >
               <i className="fa fa-cog"></i>
             </OverlayCell>
-            <OverlayCell id="map-button" ariaLabel="карта" ariaHidden="true">
+            <OverlayCell id="map-button" ariaLabel={t('ov.map', lang)} ariaHidden="true">
               <i className="fa fa-map"></i>
             </OverlayCell>
             <OverlayCell id="font-plus-button" ariaHidden="true">
@@ -190,7 +192,7 @@ const Overlay = ({ unread, onScrollToBottom }) => {
             margin: '0.5em',
           }}
         >
-          <span>{`${unread} unread message${unread > 1 ? 's' : ''}`}</span>
+          <span>{fmt('ov.unread', unread, lang)}</span>
         </button>
       )}
     </Box>
@@ -200,6 +202,7 @@ const Overlay = ({ unread, onScrollToBottom }) => {
 export default function MainWindow() {
   const terminal = useRef();
   const [unread, setUnread] = useState(0);
+  const lang = useSelector(state => state.prompt && state.prompt.lang);
 
   return (
     <Box flex="1" display="flex" flexDirection="column">
@@ -207,6 +210,7 @@ export default function MainWindow() {
         <Overlay
           unread={unread}
           onScrollToBottom={() => terminal.current.scrollToBottom()}
+          lang={lang}
         />
         <Terminal
           ref={terminal}

--- a/src/components/stats.jsx
+++ b/src/components/stats.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { usePrompt } from '../react-hooks';
+import { t } from '../i18n';
 import Box from '@mui/material/Box';
 import useMediaQuery from '@mui/material/useMediaQuery';
 import { useTheme } from '@mui/material/styles';
@@ -78,7 +79,9 @@ const StatPercent = ({ percent, caption, color }) => {
 export default function Stats() {
   const theme = useTheme();
   const big = useMediaQuery(theme.breakpoints.up('sm'));
-  const { hit, max_hit, mana, max_mana, move, max_move, fight } = usePrompt();
+  const prompt = usePrompt();
+  const { hit, max_hit, mana, max_mana, move, max_move, fight } = prompt;
+  const lang = prompt.lang;
 
   return (
     <Box
@@ -87,10 +90,10 @@ export default function Stats() {
         flexDirection: 'row',
       }}
     >
-      <Stat caption="Здоровье" color="#cc0000" v={hit} max_v={max_hit} />
-      <StatPercent caption="Противник" color="#ff0000" percent={fight} />
-      <Stat caption="Мана" color="#3465a4" v={mana} max_v={max_mana} />
-      <Stat caption="Шаги" color="#4e9a06" v={move} max_v={max_move} />
+      <Stat caption={t('st.health', lang)} color="#cc0000" v={hit} max_v={max_hit} />
+      <StatPercent caption={t('st.enemy', lang)} color="#ff0000" percent={fight} />
+      <Stat caption={t('st.mana', lang)} color="#3465a4" v={mana} max_v={max_mana} />
+      <Stat caption={t('st.moves', lang)} color="#4e9a06" v={move} max_v={max_move} />
     </Box>
   );
 }

--- a/src/components/terminal.jsx
+++ b/src/components/terminal.jsx
@@ -6,6 +6,7 @@ import historyDb from '../historydb';
 import ansi2html from '../ansi2html';
 import manip from '../manip';
 import { processTriggers } from './sysCommands/action';
+import { t } from '../i18n';
 
 // TODO: the following parameters should be replaced with two numbers - viewport size (in pixels) and the threshold (in pixels)
 const bytesToLoad = 100000; // how much stuff to load from the database in one go, when we hit the threshold (bytes)
@@ -215,7 +216,7 @@ function terminalInit(wrap) {
     echo('<hr>');
     echo(
       ansi2html(
-        '\u001b[1;31m#################### ИСТОРИЯ ЧАТА ЗАГРУЖЕНА ####################\u001b[0;37m\n'
+        '\u001b[1;31m#################### ' + t('term.historyLoaded') + ' ####################\u001b[0;37m\n'
       )
     );
     echo('<hr>');

--- a/src/components/windowletsPanel/commandButtons.jsx
+++ b/src/components/windowletsPanel/commandButtons.jsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { useSelector } from 'react-redux'
 import PanelItem from './panelItem'
+import { t } from '../../i18n'
 
 // const ButtonItem = (button) => {
 //     return (
@@ -15,26 +16,29 @@ export default function CommandButtons() {
     if(!prompt)
         return null;
 
+    // data-action stays in Russian: it is the command sent to the engine, which
+    // resolves RU aliases regardless of the player's display language. Only the
+    // visible label is localized.
+    const l = prompt.lang;
+
     return (
-        <PanelItem title="Команды">
+        <PanelItem storageKey="commands" title={t('cmd.title', l)}>
             <div id="commands-table" className="flexcontainer-row collapse show">
                 <div className="flexcontainer-column">
-                    <button type="button" className="btn btn-ctrl-panel" data-action="см">Смотреть</button>
-                    {/* <ButtonItem action='см' title='Смотреть'></ButtonItem> */}
-                    <button type="button" className="btn btn-ctrl-panel" data-action="инв">Инвентарь</button>
-                    <button type="button" className="btn btn-ctrl-panel" data-action="одежда">Одежда</button>
-                    <button type="button" className="btn btn-ctrl-panel" data-action="ссчет">Счет</button>
-                    <button type="button" className="btn btn-ctrl-panel" data-action="/">Возврат</button>
-                    <button type="button" className="btn btn-ctrl-panel" data-action="сбежать">Сбежать</button>
+                    <button type="button" className="btn btn-ctrl-panel" data-action="см">{t('cmd.look', l)}</button>
+                    <button type="button" className="btn btn-ctrl-panel" data-action="инв">{t('cmd.inv', l)}</button>
+                    <button type="button" className="btn btn-ctrl-panel" data-action="одежда">{t('cmd.equip', l)}</button>
+                    <button type="button" className="btn btn-ctrl-panel" data-action="ссчет">{t('cmd.score', l)}</button>
+                    <button type="button" className="btn btn-ctrl-panel" data-action="/">{t('cmd.recall', l)}</button>
+                    <button type="button" className="btn btn-ctrl-panel" data-action="сбежать">{t('cmd.flee', l)}</button>
                 </div>
                 <div className="flexcontainer-column">
-                    <button type="button" className="btn btn-ctrl-panel" data-action="прак">Практика</button>
-                    <button type="button" className="btn btn-ctrl-panel" data-action="умения заклинания">Магия</button>
-                    <button type="button" className="btn btn-ctrl-panel" data-action="умения навыки">Умения</button>
-                    <button type="button" className="btn btn-ctrl-panel" data-action="задания">Задания</button> 
-                    <button type="button" className="btn btn-ctrl-panel" data-action="команды">Команды</button>
-                    {/* <ButtonItem action='конец' confirm='покинуть мир' title='Конец'></ButtonItem> */}
-                    <button type="button" className="btn btn-ctrl-panel" data-action="конец" data-confirm="покинуть мир">Конец</button>
+                    <button type="button" className="btn btn-ctrl-panel" data-action="прак">{t('cmd.practice', l)}</button>
+                    <button type="button" className="btn btn-ctrl-panel" data-action="умения заклинания">{t('cmd.magic', l)}</button>
+                    <button type="button" className="btn btn-ctrl-panel" data-action="умения навыки">{t('cmd.skills', l)}</button>
+                    <button type="button" className="btn btn-ctrl-panel" data-action="задания">{t('cmd.quests', l)}</button>
+                    <button type="button" className="btn btn-ctrl-panel" data-action="команды">{t('cmd.title', l)}</button>
+                    <button type="button" className="btn btn-ctrl-panel" data-action="конец" data-confirm={t('cmd.quitConfirm', l)}>{t('cmd.quit', l)}</button>
                 </div>
             </div>
         </PanelItem>

--- a/src/components/windowletsPanel/groupItem.jsx
+++ b/src/components/windowletsPanel/groupItem.jsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import PanelItem from './panelItem'
+import { t } from '../../i18n'
 
 
 // prompt 'group' fields: ln - leader name in genitive case,
@@ -20,15 +21,15 @@ const TeamMate = (stats) => {
 
 export default function GroupItem(prompt) {
 
-    return <PanelItem storageKey="group" title={'Группа ' + prompt.group.ln} collapsed={true} >
+    return <PanelItem storageKey="group" title={t('grp.title', prompt.lang) + ' ' + prompt.group.ln} collapsed={true} >
             <div id="group-table">
                 <table>
                     <thead>
                         <tr>
-                            <th>Имя</th>
-                            <th>Ур.</th>
-                            <th>Здор.</th>
-                            <th>Опыт</th>
+                            <th>{t('grp.name', prompt.lang)}</th>
+                            <th>{t('grp.lvl', prompt.lang)}</th>
+                            <th>{t('grp.health', prompt.lang)}</th>
+                            <th>{t('grp.exp', prompt.lang)}</th>
                         </tr>
                     </thead>
                     <tbody>

--- a/src/components/windowletsPanel/locationItem.jsx
+++ b/src/components/windowletsPanel/locationItem.jsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import PanelItem from './panelItem'
+import { t } from '../../i18n'
 
 // Prompt zone field: string with area name.
 const ZoneRow = ({zone}) => {
@@ -40,11 +41,12 @@ const ExitCell = ({ex_ru, ex_en, ex_hidden, ex_visible, lang}) => {
     return <span className={`${color}`}>{letter}</span> 
 };
 
-// Prompt exits field: e - open exits, h - closed exits, l - language (r, e)
-const ExitsRow = ({e, h, l}) => {
+// Prompt exits field: e - open exits, h - closed exits, l - exit-letter language (r, e).
+// uilang is the UI display language (en/ru/ua) for the "exits:" label, kept separate.
+const ExitsRow = ({e, h, l, uilang}) => {
     return <tr>
         <td className="v-top">&nbsp;<i className="fa">&#xf277;</i></td>
-        <td className="v-bottom">выходы:&nbsp;
+        <td className="v-bottom">{t('loc.exits', uilang)}&nbsp;
             <ExitCell ex_ru='С' ex_en='N' ex_hidden={h} ex_visible={e} lang={l} />
             <ExitCell ex_ru='В' ex_en='E' ex_hidden={h} ex_visible={e} lang={l} />
             <ExitCell ex_ru='Ю' ex_en='S' ex_hidden={h} ex_visible={e} lang={l} />
@@ -70,12 +72,12 @@ export default function LocationItem(prompt) {
 
     const { zone, room, exits, sect } = prompt;
 
-    return <PanelItem title="Твое местоположение">
+    return <PanelItem storageKey="location" title={t('loc.title', prompt.lang)}>
         <table>
             <tbody>
                 { zone && zone !== 'none' && <ZoneRow zone={zone} /> }
                 { room && room !== 'none' && <RoomRow room={room} /> }
-                { exits && exits !== 'none' && <ExitsRow {...exits} /> }
+                { exits && exits !== 'none' && <ExitsRow {...exits} uilang={prompt.lang} /> }
                 { sect && sect !== 'none' && <SectorRow {...sect} /> }
             </tbody>
         </table>

--- a/src/components/windowletsPanel/panelHelp.jsx
+++ b/src/components/windowletsPanel/panelHelp.jsx
@@ -2,6 +2,8 @@ import $ from 'jquery';
 import React, { useState, useEffect, useRef } from 'react';
 
 import { send } from '../../websock';
+import { usePrompt } from '../../react-hooks';
+import { t } from '../../i18n';
 
 const echo = txt => {
   $('.terminal').trigger('output', [txt]);
@@ -42,6 +44,10 @@ const useTypeahead = () => {
 export default function Help() {
   const ref = useRef();
   const { loading, topics, error } = useTypeahead();
+  // Subscribe to the prompt so a `config language` switch re-renders the labels.
+  // t() falls back to the last-known language when a delta prompt omits lang.
+  const prompt = usePrompt();
+  const lang = prompt && prompt.lang;
 
   const showTopic = function (topic) {
     const inputbox = $(ref.current);
@@ -70,7 +76,7 @@ export default function Help() {
         lookupLimit: 10,
         autoSelectFirst: true,
         showNoSuggestionNotice: true,
-        noSuggestionNotice: 'Справка не найдена',
+        noSuggestionNotice: t('help.notFound', lang),
         formatResult: function (suggestion, currentValue) {
           let s = {};
           s.data = suggestion.data;
@@ -82,7 +88,7 @@ export default function Help() {
     }
 
     return () => inputbox.off();
-  }, [loading, topics, error]);
+  }, [loading, topics, error, lang]);
 
   return (
     <div id="help" className="table-wrapper">
@@ -91,7 +97,7 @@ export default function Help() {
         data-toggle="collapse"
         data-target="#help-table"
       >
-        Поиск по справке
+        {t('help.title', lang)}
       </span>
       <button
         className="close"
@@ -107,7 +113,7 @@ export default function Help() {
           ref={ref}
           type="text"
           className="form-control"
-          placeholder="Введи ключевое слово"
+          placeholder={t('help.placeholder', lang)}
           disabled={loading}
         />
       </div>

--- a/src/components/windowletsPanel/playerParamsItem.jsx
+++ b/src/components/windowletsPanel/playerParamsItem.jsx
@@ -1,23 +1,25 @@
 import React from 'react'
 import PanelItem from "./panelItem";
+import { t } from '../../i18n';
 
 // prompt params fields p1: ps - array of permanent stats, cs - array of current stats.
 // prompt params fields p2: h - hitroll, d - damroll, a - armor class, s - saves vs spell.
 const BaseStats = (stats) => {
+    const l = stats.lang;
     return (
         <table id="player-params-1">
             <tbody>
                 <tr>
-                    <td><b>Сила</b>:</td><td>{stats.ps[0]}(<b>{stats.cs[0]}</b>)</td>
-                    <td><b>Ум</b>:</td><td>{stats.ps[1]}(<b>{stats.cs[1]}</b>)</td>
+                    <td><b>{t('par.str', l)}</b>:</td><td>{stats.ps[0]}(<b>{stats.cs[0]}</b>)</td>
+                    <td><b>{t('par.int', l)}</b>:</td><td>{stats.ps[1]}(<b>{stats.cs[1]}</b>)</td>
                 </tr>
                 <tr>
-                    <td><b>Мудр</b>:</td><td>{stats.ps[2]}(<b>{stats.cs[2]}</b>)</td>
-                    <td><b>Ловк</b>:</td><td>{stats.ps[3]}(<b>{stats.cs[3]}</b>)</td>
+                    <td><b>{t('par.wis', l)}</b>:</td><td>{stats.ps[2]}(<b>{stats.cs[2]}</b>)</td>
+                    <td><b>{t('par.dex', l)}</b>:</td><td>{stats.ps[3]}(<b>{stats.cs[3]}</b>)</td>
                 </tr>
                 <tr>
-                    <td><b>Слож</b>:</td><td>{stats.ps[4]}(<b>{stats.cs[4]}</b>)</td>
-                    <td><b>Обая</b>:</td><td>{stats.ps[5]}(<b>{stats.cs[5]}</b>)</td>
+                    <td><b>{t('par.con', l)}</b>:</td><td>{stats.ps[4]}(<b>{stats.cs[4]}</b>)</td>
+                    <td><b>{t('par.cha', l)}</b>:</td><td>{stats.ps[5]}(<b>{stats.cs[5]}</b>)</td>
                 </tr>
             </tbody>
         </table>
@@ -25,16 +27,17 @@ const BaseStats = (stats) => {
 }
 
 const SecondaryStats = (stats) => {
+    const l = stats.lang;
     return (
         <table id="player-params-2">
             <tbody>
                 <tr>
-                    <td><b>Точность</b>:</td><td>{stats.h}</td>
-                    <td><b>Урон</b>:</td><td>{stats.d}</td>
+                    <td><b>{t('par.hit', l)}</b>:</td><td>{stats.h}</td>
+                    <td><b>{t('par.dam', l)}</b>:</td><td>{stats.d}</td>
                 </tr>
                 <tr>
-                    <td><b>Броня</b>:</td><td>{stats.a}</td>
-                    <td><b>Заклин</b>:</td><td>{stats.s}</td>
+                    <td><b>{t('par.ac', l)}</b>:</td><td>{stats.a}</td>
+                    <td><b>{t('par.save', l)}</b>:</td><td>{stats.s}</td>
                 </tr>
             </tbody>
         </table>
@@ -44,11 +47,11 @@ const SecondaryStats = (stats) => {
 export default function PlayerParamsItem(prompt) {
 
     return (
-        <PanelItem title="Твои параметры" collapsed={true}>
+        <PanelItem storageKey="params" title={t('par.title', prompt.lang)} collapsed={true}>
             <div id="player-params-table" data-hint="hint-params">
-                {(prompt.p1 && prompt.p1 !== "none") && <BaseStats {...prompt.p1} />}
+                {(prompt.p1 && prompt.p1 !== "none") && <BaseStats {...prompt.p1} lang={prompt.lang} />}
                 <br/>
-                {(prompt.p2 && prompt.p2 !== "none") && <SecondaryStats {...prompt.p2} />}
+                {(prompt.p2 && prompt.p2 !== "none") && <SecondaryStats {...prompt.p2} lang={prompt.lang} />}
             </div>
         </PanelItem>
     )

--- a/src/components/windowletsPanel/questorItem.jsx
+++ b/src/components/windowletsPanel/questorItem.jsx
@@ -1,11 +1,12 @@
 import React from 'react'
 import PanelItem from "./panelItem"
+import { t } from '../../i18n'
 
 // prompt questor quest info 'q' fields: t - remaining time, i - short quest info.
 export default function QuestorItem(prompt) {
 
     return (
-        <PanelItem storageKey="questor" title={<span>{'Задание квестора: '}<span className='fgby'> {prompt.q.t} </span>{' мин'}</span>}>
+        <PanelItem storageKey="questor" title={<span>{t('qst.title', prompt.lang) + ' '}<span className='fgby'> {prompt.q.t} </span>{' ' + t('qst.min', prompt.lang)}</span>}>
             <div id="questor-table" data-hint="hint-questor">
                 <p className="fgbw">{prompt.q.i}</p>
             </div>

--- a/src/components/windowletsPanel/timeWeatherItem.jsx
+++ b/src/components/windowletsPanel/timeWeatherItem.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import PanelItem from './panelItem';
+import { t } from '../../i18n';
 import Table from '@mui/material/Table';
 import TableBody from '@mui/material/TableBody';
 import TableRow from '@mui/material/TableRow';
@@ -49,7 +50,7 @@ export default function TimeWeatherItem(prompt) {
   const { time, date, w: weather } = prompt;
 
   return (
-    <PanelItem title="Погода и время">
+    <PanelItem storageKey="timeWeather" title={t('tw.title', prompt.lang)}>
       <Table sx={{
         // Compact rows; icons share one uniform box, aligned to the left edge with an
         // 8px gap to the text, tinted to the client purple.

--- a/src/components/windowletsPanel/whoItem.jsx
+++ b/src/components/windowletsPanel/whoItem.jsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import PanelItem from "./panelItem"
-import { Races, Clans } from './windowletsConstants' 
+import { Races, Clans } from './windowletsConstants'
+import { t } from '../../i18n'
 
 // prompt 'who' fields: p - list of players, v - visible player count,
 // t - total player count.
@@ -19,14 +20,14 @@ const WhoPlayer = (person) => {
 export default function WhoItem(prompt) {
 
     return (
-        <PanelItem title="Сейчас в мире">
+        <PanelItem storageKey="who" title={t('who.title', prompt.lang)}>
             <div id="who-table" data-hint="hint-who">
                 <table>
                     <thead>
                         <tr>
-                            <th>Имя</th>
-                            <th>Раса</th>
-                            <th>Клан</th>
+                            <th>{t('who.name', prompt.lang)}</th>
+                            <th>{t('who.race', prompt.lang)}</th>
+                            <th>{t('who.clan', prompt.lang)}</th>
                         </tr>
                     </thead>
                     <tbody>

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -1,0 +1,236 @@
+import $ from 'jquery';
+
+// Central client-side i18n for the mudjs UI chrome (panel titles, column headers,
+// button labels, ARIA labels, placeholders). The player's display language
+// ("en"/"ru"/"ua") arrives on every web prompt as b.lang (server side:
+// Player::displayLang -> interprethandler webPrompt). We cache the last value and
+// DEFAULT TO ENGLISH until the first prompt, matching the "EN default" policy.
+//
+// Two ways to localize a string:
+//   * components that already receive the prompt pass it explicitly: t(key, prompt.lang)
+//     -- these re-render on every prompt, so a live `config language` switch updates them;
+//   * static components with no prompt (help search, input bar, overlay, terminal) call
+//     t(key) and rely on getLang(). Those pick up a language change on their next render.
+//
+// Only UI CHROME lives here. Game text (room/act/affect labels) is localized on the
+// server and arrives already in the player's language.
+
+let currentLang = 'en';
+
+$(function () {
+  $('#rpc-events').on('rpc-prompt', function (e, b) {
+    if (b && b.lang != null) currentLang = b.lang;
+  });
+});
+
+export function getLang() {
+  return currentLang;
+}
+
+// Mostly for explicit control / tests; the prompt handler above is the normal path.
+export function setLang(lang) {
+  if (lang != null) currentLang = lang;
+}
+
+const STRINGS = {
+  en: {
+    // time & weather panel
+    'tw.title': 'Weather & time',
+    // group panel
+    'grp.title': 'Group',
+    'grp.name': 'Name',
+    'grp.lvl': 'Lvl',
+    'grp.health': 'Health',
+    'grp.exp': 'Exp',
+    // who panel
+    'who.title': 'Online now',
+    'who.name': 'Name',
+    'who.race': 'Race',
+    'who.clan': 'Clan',
+    // player params panel
+    'par.title': 'Your stats',
+    'par.str': 'Str',
+    'par.int': 'Int',
+    'par.wis': 'Wis',
+    'par.dex': 'Dex',
+    'par.con': 'Con',
+    'par.cha': 'Cha',
+    'par.hit': 'Hit',
+    'par.dam': 'Dam',
+    'par.ac': 'AC',
+    'par.save': 'Save',
+    // location panel
+    'loc.title': 'Your location',
+    'loc.exits': 'exits:',
+    // questor panel
+    'qst.title': 'Questor task:',
+    'qst.min': 'min',
+    // command buttons
+    'cmd.title': 'Commands',
+    'cmd.look': 'Look',
+    'cmd.inv': 'Inventory',
+    'cmd.equip': 'Equipment',
+    'cmd.score': 'Score',
+    'cmd.recall': 'Recall',
+    'cmd.flee': 'Flee',
+    'cmd.practice': 'Practice',
+    'cmd.magic': 'Spells',
+    'cmd.skills': 'Skills',
+    'cmd.quests': 'Quests',
+    'cmd.quit': 'Quit',
+    'cmd.quitConfirm': 'leave the world',
+    // help search panel
+    'help.title': 'Help search',
+    'help.placeholder': 'Enter a keyword',
+    'help.notFound': 'No help found',
+    // vital bars
+    'st.health': 'Health',
+    'st.enemy': 'Enemy',
+    'st.mana': 'Mana',
+    'st.moves': 'Moves',
+    // command input bar (ARIA + reconnect)
+    'in.repeat': 'Repeat command',
+    'in.next': 'Next command',
+    'in.prev': 'Previous command',
+    'in.reconnect': 'Reconnect',
+    // overlay buttons (ARIA) + unread badge ("%d" = count)
+    'ov.logs': 'logs',
+    'ov.settings': 'settings',
+    'ov.map': 'map',
+    'ov.unread': '%d unread',
+    // terminal
+    'term.historyLoaded': 'CHAT HISTORY LOADED',
+    // input placeholder hint ("%s" = example command)
+    'ph.example': 'Type a command, e.g.: %s',
+  },
+  ru: {
+    'tw.title': 'Погода и время',
+    'grp.title': 'Группа',
+    'grp.name': 'Имя',
+    'grp.lvl': 'Ур.',
+    'grp.health': 'Здор.',
+    'grp.exp': 'Опыт',
+    'who.title': 'Сейчас в мире',
+    'who.name': 'Имя',
+    'who.race': 'Раса',
+    'who.clan': 'Клан',
+    'par.title': 'Твои параметры',
+    'par.str': 'Сила',
+    'par.int': 'Ум',
+    'par.wis': 'Мудр',
+    'par.dex': 'Ловк',
+    'par.con': 'Слож',
+    'par.cha': 'Обая',
+    'par.hit': 'Точность',
+    'par.dam': 'Урон',
+    'par.ac': 'Броня',
+    'par.save': 'Заклин',
+    'loc.title': 'Твое местоположение',
+    'loc.exits': 'выходы:',
+    'qst.title': 'Задание квестора:',
+    'qst.min': 'мин',
+    'cmd.title': 'Команды',
+    'cmd.look': 'Смотреть',
+    'cmd.inv': 'Инвентарь',
+    'cmd.equip': 'Одежда',
+    'cmd.score': 'Счет',
+    'cmd.recall': 'Возврат',
+    'cmd.flee': 'Сбежать',
+    'cmd.practice': 'Практика',
+    'cmd.magic': 'Магия',
+    'cmd.skills': 'Умения',
+    'cmd.quests': 'Задания',
+    'cmd.quit': 'Конец',
+    'cmd.quitConfirm': 'покинуть мир',
+    'help.title': 'Поиск по справке',
+    'help.placeholder': 'Введи ключевое слово',
+    'help.notFound': 'Справка не найдена',
+    'st.health': 'Здоровье',
+    'st.enemy': 'Противник',
+    'st.mana': 'Мана',
+    'st.moves': 'Шаги',
+    'in.repeat': 'Повторить команду',
+    'in.next': 'Следующая команда',
+    'in.prev': 'Предыдущая команда',
+    'in.reconnect': 'Переподключиться',
+    'ov.logs': 'логи',
+    'ov.settings': 'настройки',
+    'ov.map': 'карта',
+    'ov.unread': 'Непрочитано: %d',
+    'term.historyLoaded': 'ИСТОРИЯ ЧАТА ЗАГРУЖЕНА',
+    'ph.example': 'Введи команду, например: %s',
+  },
+  ua: {
+    'tw.title': 'Погода і час',
+    'grp.title': 'Група',
+    'grp.name': 'Імʼя',
+    'grp.lvl': 'Рів.',
+    'grp.health': 'Здор.',
+    'grp.exp': 'Досв.',
+    'who.title': 'Зараз у світі',
+    'who.name': 'Імʼя',
+    'who.race': 'Раса',
+    'who.clan': 'Клан',
+    'par.title': 'Твої параметри',
+    'par.str': 'Сила',
+    'par.int': 'Розум',
+    'par.wis': 'Мудр',
+    'par.dex': 'Сприт',
+    'par.con': 'Статура',
+    'par.cha': 'Харизма',
+    'par.hit': 'Влучність',
+    'par.dam': 'Шкода',
+    'par.ac': 'Броня',
+    'par.save': 'Чари',
+    'loc.title': 'Твоє місцезнаходження',
+    'loc.exits': 'виходи:',
+    'qst.title': 'Завдання квестора:',
+    'qst.min': 'хв',
+    'cmd.title': 'Команди',
+    'cmd.look': 'Дивитись',
+    'cmd.inv': 'Інвентар',
+    'cmd.equip': 'Одяг',
+    'cmd.score': 'Стан',
+    'cmd.recall': 'Поверн.',
+    'cmd.flee': 'Втекти',
+    'cmd.practice': 'Практика',
+    'cmd.magic': 'Магія',
+    'cmd.skills': 'Уміння',
+    'cmd.quests': 'Завдання',
+    'cmd.quit': 'Вихід',
+    'cmd.quitConfirm': 'покинути світ',
+    'help.title': 'Пошук у довідці',
+    'help.placeholder': 'Введи ключове слово',
+    'help.notFound': 'Довідку не знайдено',
+    'st.health': 'Здоровʼя',
+    'st.enemy': 'Ворог',
+    'st.mana': 'Мана',
+    'st.moves': 'Кроки',
+    'in.repeat': 'Повторити команду',
+    'in.next': 'Наступна команда',
+    'in.prev': 'Попередня команда',
+    'in.reconnect': 'Перепідключитися',
+    'ov.logs': 'логи',
+    'ov.settings': 'налаштування',
+    'ov.map': 'карта',
+    'ov.unread': 'Непрочитано: %d',
+    'term.historyLoaded': 'ІСТОРІЯ ЧАТУ ЗАВАНТАЖЕНА',
+    'ph.example': 'Введи команду, наприклад: %s',
+  },
+};
+
+// t(key, lang?) -- look up a UI string. `lang` defaults to the current display language.
+// Falls back to English, then to the key itself, so a missing translation degrades
+// visibly-but-safely instead of throwing. Placeholders "%d"/"%s" are substituted via fmt().
+export function t(key, lang) {
+  const l = lang || currentLang;
+  const table = STRINGS[l] || STRINGS.en;
+  if (table[key] != null) return table[key];
+  if (STRINGS.en[key] != null) return STRINGS.en[key];
+  return key;
+}
+
+// fmt(key, value, lang?) -- t() with the first "%d"/"%s" placeholder replaced by `value`.
+export function fmt(key, value, lang) {
+  return t(key, lang).replace(/%[ds]/, value);
+}

--- a/src/location.js
+++ b/src/location.js
@@ -1,6 +1,7 @@
 import $ from 'jquery';
 import getSessionId from './sessionid.js';
 import placeholders from './data/placeholders.json' assert { type: 'json' };
+import { fmt } from './i18n';
 
 const sessionId = getSessionId();
 var lastLocation, locationChannel;
@@ -59,7 +60,7 @@ function createPlaceholder(loc) {
     if (!lastLocation || loc.vnum !== lastLocation.vnum) index = 0;
     else index = Math.floor(Math.random() * roomhints.length);
 
-    return 'Введи команду, например: ' + roomhints[index];
+    return fmt('ph.example', roomhints[index], loc.lang);
   }
 
   return '';


### PR DESCRIPTION
Second i18n step after the affects panel: make the **whole visible widget surface** trilingual (EN/RU/UA), with **EN as the default** and the language read from the player's `config language` (the web prompt's `b.lang`).

## New: `src/i18n.js`
A small central helper — no i18n library:
- `t(key, lang?)` / `fmt(key, value, lang?)` — look up a UI string; `lang` defaults to the cached display language; falls back to English, then the key.
- caches `b.lang` from every prompt, **defaults to English** until the first prompt.
- ~50 UI-chrome keys in `en`/`ru`/`ua` tables.

## Localized
- **Panels:** time/weather, group, who, player params, location, questor, command buttons, help search — titles, column headers, stat labels, button labels, placeholders.
- **Vital bars:** health / enemy / mana / moves.
- **Core UI:** command-input ARIA labels + Reconnect, overlay ARIA labels (logs/settings/map) + unread badge, chat-history banner, input placeholder hint.

ARIA labels matter here — ~30% of players use screen readers, and they now read in the player's language.

## How lang flows
Widgets that receive the prompt pass `t(key, prompt.lang)` and update on a live `config language` switch. Static components (input bar, overlay) read the **merged** store lang via `useSelector`, so they re-render only on an actual change. Panels whose title became dynamic got a stable `storageKey` so collapsed state still persists across a language switch.

`data-action` command strings stay Russian — the engine resolves RU aliases regardless of display language; only the visible labels are translated.

## Out of scope (follow-ups)
- who-panel race/clan name dicts (`windowletsConstants.js`) — overlaps with server-side race-name localization.
- `sysCommands/*` `#`-command help text.
- server-driven exit-letter language.

Validated with `vite build` (1035 modules, clean).