### PR TITLE
client i18n: trilingual who-panel names + affect-panel cleanup

### DIFF
--- a/src/components/windowletsPanel/affectsItem.jsx
+++ b/src/components/windowletsPanel/affectsItem.jsx
@@ -1,22 +1,8 @@
 import React from 'react'
 import PanelItem from './panelItem'
-import { Cnames, Dnames, Enames, Pnames, Tnames, Mnames } from './windowletsConstants';
+import { t } from '../../i18n';
 
-// Column headers, localized by the player's `config language` (prompt.lang). Kept inline
-// here until the app-wide i18n module lands; when it does, swap this map for useT().
-const HEADERS = {
-    en: { title: 'Affects on you', pro: 'Prot', det: 'Detect', trv: 'Travel', enh: 'Boost', mal: 'Curse', cln: 'Clan' },
-    ru: { title: 'Воздействия на тебе', pro: 'Защита', det: 'Обнар', trv: 'Трансп', enh: 'Усилен', mal: 'Отриц', cln: 'Клан' },
-    ua: { title: 'Впливи на тебе', pro: 'Захист', det: 'Виявл', trv: 'Трансп', enh: 'Підсил', mal: 'Негат', cln: 'Клан' },
-};
-function hdr(lang) { return HEADERS[lang] || HEADERS.en; }
-
-// Legacy char-dict fallback for the old wire format ({a,z} strings of single-char keys).
-// The server switches to the dynamic per-affect format ([{n,x}]); this branch keeps the
-// panel working during the transition and can be deleted once the C++ bundle is live.
-const LEGACY_NAMES = { pro: Pnames, det: Dnames, trv: Tnames, enh: Enames, mal: Mnames, cln: Cnames };
-
-// Six fixed columns; membership is now driven by the server, not hardcoded here.
+// Six fixed columns; membership is driven by the server, not hardcoded here.
 // Base column color: 2 = green (buffs), 1 = red (maladictions) -- kept for the active state.
 // Duration only adds two overrides on top: permanent = cyan (6), about to expire = yellow (3).
 // See affColor().
@@ -30,9 +16,7 @@ const COLUMNS = [
 ];
 
 function hasAffects(block) {
-    if (block == null || block === 'none') return false;
-    if (Array.isArray(block)) return block.length > 0;   // new format
-    return block.a != null && block.a !== '';            // legacy {a,z}
+    return Array.isArray(block) && block.length > 0;
 }
 
 // Color one affect by its remaining duration `d` (ticks; -1 = permanent). This only
@@ -40,42 +24,18 @@ function hasAffects(block) {
 //   permanent    -> light cyan  ({C, ANSI bright 6)
 //   about to expire (<= 1 tick) -> yellow (bright 3)
 //   otherwise    -> column base color (unchanged: red maladictions, green buffs)
-// Falls back to the legacy binary `x` expiring flag when the server hasn't sent `d` yet.
 function affColor(aff, baseColor) {
     const d = aff.d;
-    if (d === -1) return 'fg-ansi-bright-color-6';        // permanent -> cyan
-    if (d != null) {
-        if (d <= 1) return 'fg-ansi-bright-color-3';      // about to expire -> yellow
-        return 'fg-ansi-bright-color-' + baseColor;       // otherwise -> column base
-    }
-    return aff.x ? 'fg-ansi-bright-color-3' : 'fg-ansi-bright-color-' + baseColor;
+    if (d === -1) return 'fg-ansi-bright-color-6';            // permanent -> cyan
+    if (d != null && d <= 1) return 'fg-ansi-bright-color-3'; // about to expire -> yellow
+    return 'fg-ansi-bright-color-' + baseColor;               // otherwise -> column base
 }
 
-// Draw one column. Handles BOTH the new dynamic format and the legacy char-dict format.
+// Draw one column: the server already localized each affect's label `n`.
 function AffectBlock(props) {
-    const clr_active = 'fg-ansi-bright-color-' + props.color;
-    const clr_zero = 'fg-ansi-bright-color-3';
-    const rows = [];
-
-    if (Array.isArray(props.block)) {
-        // New format: server already localized `n`; `d` = remaining ticks (-1 = permanent).
-        props.block.forEach(function (aff, idx) {
-            rows.push(<span key={idx} className={affColor(aff, props.color)}>{aff.n}</span>);
-        });
-    } else {
-        // Legacy format: {a,z} char strings mapped through the hardcoded RU dict.
-        const names = props.bitNames || {};
-        const active = props.block.a || '';
-        const zero = props.block.z || '';
-        for (const bit in names) {
-            if (!names.hasOwnProperty(bit)) continue;
-            let clr;
-            if (zero.indexOf(bit) !== -1) clr = clr_zero;
-            else if (active.indexOf(bit) !== -1) clr = clr_active;
-            else continue;
-            rows.push(<span key={bit} className={clr}>{names[bit]}</span>);
-        }
-    }
+    const rows = props.block.map(function (aff, idx) {
+        return <span key={idx} className={affColor(aff, props.color)}>{aff.n}</span>;
+    });
 
     if (rows.length === 0) return null;
 
@@ -88,10 +48,10 @@ function AffectBlock(props) {
 }
 
 export default function AffectsItem(prompt) {
-    const h = hdr(prompt.lang);
+    const l = prompt.lang;
 
     return (
-        <PanelItem title={h.title}>
+        <PanelItem storageKey="affects" title={t('aff.title', l)}>
             <div id="player-affects-table" className="flexcontainer-row flexcontainer-wrap " data-hint="hint-affects">
                 { COLUMNS.map(function (c) {
                     if (!hasAffects(prompt[c.key])) return null;
@@ -99,8 +59,7 @@ export default function AffectsItem(prompt) {
                         <AffectBlock
                             key={c.key}
                             block={prompt[c.key]}
-                            blockName={h[c.key]}
-                            bitNames={LEGACY_NAMES[c.key]}
+                            blockName={t('aff.' + c.key, l)}
                             color={c.color}
                             type={c.type}
                         />

--- a/src/components/windowletsPanel/whoItem.jsx
+++ b/src/components/windowletsPanel/whoItem.jsx
@@ -1,18 +1,19 @@
 import React from 'react'
 import PanelItem from "./panelItem"
-import { Races, Clans } from './windowletsConstants'
+import { raceName, clanName } from './windowletsConstants'
 import { t } from '../../i18n'
 
 // prompt 'who' fields: p - list of players, v - visible player count,
 // t - total player count.
 // Each player contains fields: n - name, r - first 2 letters of race,
-// cn - first letter of clan name, cc - clan colour.
+// cn - first letter of clan name, cc - clan colour. lang is threaded in for the
+// localized race/clan names.
 const WhoPlayer = (person) => {
     return (
         <tr>
             <td>{person.n}</td>
-            <td>{Races[person.r]}</td>
-            {person.cn ? <td><span className={'fg' + person.cc }> {Clans[person.cn]}</span></td> : <td></td>}
+            <td>{raceName(person.r, person.lang)}</td>
+            {person.cn ? <td><span className={'fg' + person.cc }> {clanName(person.cn, person.lang)}</span></td> : <td></td>}
         </tr>
     )
 }
@@ -33,7 +34,7 @@ export default function WhoItem(prompt) {
                     <tbody>
                         {prompt.who.p.map((person,i) => {
                             return (
-                                <WhoPlayer key={i} {...person} />
+                                <WhoPlayer key={i} {...person} lang={prompt.lang} />
                             )
                         })}
                     </tbody>

--- a/src/components/windowletsPanel/windowletsConstants.js
+++ b/src/components/windowletsPanel/windowletsConstants.js
@@ -1,169 +1,62 @@
-export const Races = {
-    'ar': 'Ариал',
-    'ce': 'Кентавр',
-    'cl': 'ОбВелик',
-    'da': 'ТемЭльф',
-    'dr': 'Дроу',
-    'du': 'Дуэргар',
-    'dw': 'Дварф',
-    'el': 'Эльф',
-    'fa': 'Фея',
-    'fe': 'Фелар',
-    'fi': 'ОгВелик',
-    'fr': 'ИнВелик',
-    'gi': 'Гитианк',
-    'gn': 'Гном',
-    'ha': 'ПолЭльф',
-    'ho': 'Хоббит',
-    'hu': 'Человек',
-    'ke': 'Кендер',
-    'ma': 'Чес',
-    'ro': 'Роксир',
-    'sa': 'Сатир',
-    'st': 'ШтВелик',
-    'sv': 'Свирф',
-    'tr': 'Тролль',
-    'ur': 'Урукха'
+// "Who" panel race + clan names, keyed by the short code the server sends.
+// Terse (<=8 chars) to fit the narrow panel column. EN = the engine's own <nameWho>
+// (races/*.xml); RU = the historical panel abbrev; UA from RACES_UA.md / clans/*.xml.
+// Game text everywhere else is localized on the server; these stay client-side because
+// the who prompt sends only a 2-letter code, not a full localized name.
+
+const RACE_NAMES = {
+    ar: { en: 'Arial', ru: 'Ариал',   ua: 'Аріал' },
+    ce: { en: 'Centa', ru: 'Кентавр', ua: 'Кентавр' },
+    cl: { en: 'ClGia', ru: 'ОбВелик', ua: 'ХмВелет' },
+    da: { en: 'D-Elf', ru: 'ТемЭльф', ua: 'ТемЕльф' },
+    dr: { en: 'Drow',  ru: 'Дроу',    ua: 'Дроу' },
+    du: { en: 'Duerg', ru: 'Дуэргар', ua: 'Дуергар' },
+    dw: { en: 'Dwarf', ru: 'Дварф',   ua: 'Дварф' },
+    el: { en: 'Elf',   ru: 'Эльф',    ua: 'Ельф' },
+    fa: { en: 'Faery', ru: 'Фея',     ua: 'Фея' },
+    fe: { en: 'Felar', ru: 'Фелар',   ua: 'Фелар' },
+    fi: { en: 'FiGia', ru: 'ОгВелик', ua: 'ВгВелет' },
+    fr: { en: 'FrGia', ru: 'ИнВелик', ua: 'КрВелет' },
+    gi: { en: 'Githy', ru: 'Гитианк', ua: 'Гітіанки' },
+    gn: { en: 'Gnome', ru: 'Гном',    ua: 'Гном' },
+    ha: { en: 'H-Elf', ru: 'ПолЭльф', ua: 'НапЕльф' },
+    ho: { en: 'Hobbi', ru: 'Хоббит',  ua: 'Гобіт' },
+    hu: { en: 'Human', ru: 'Человек', ua: 'Людина' },
+    ke: { en: 'Kendr', ru: 'Кендер',  ua: 'Кендер' },
+    ma: { en: 'Mawg',  ru: 'Чес',     ua: 'Псюрень' },
+    ro: { en: 'Rocks', ru: 'Роксир',  ua: 'Роксір' },
+    sa: { en: 'Satyr', ru: 'Сатир',   ua: 'Сатир' },
+    st: { en: 'StGia', ru: 'ШтВелик', ua: 'ШтВелет' },
+    sv: { en: 'Svirf', ru: 'Свирф',   ua: 'Свірф' },
+    tr: { en: 'Troll', ru: 'Тролль',  ua: 'Троль' },
+    ur: { en: 'Urkhi', ru: 'Урукха',  ua: 'Урукхай' },
+};
+
+const CLAN_NAMES = {
+    b: { en: 'Fury',     ru: 'Ярости',     ua: 'Ярості' },
+    c: { en: 'Chaos',    ru: 'Хаос',       ua: 'Хаос' },
+    e: { en: 'Exiles',   ru: 'Изгои',      ua: 'Ізгої' },
+    f: { en: 'Flowers',  ru: 'Цветы',      ua: 'Квіти' },
+    g: { en: 'Ghosts',   ru: 'Призраки',   ua: 'Привиди' },
+    h: { en: 'Hunters',  ru: 'Охотники',   ua: 'Мисливці' },
+    i: { en: 'Invaders', ru: 'Захватчики', ua: 'Загарбники' },
+    k: { en: 'Knights',  ru: 'Рыцари',     ua: 'Лицарі' },
+    l: { en: 'Lions',    ru: 'Львы',       ua: 'Леви' },
+    o: { en: 'Loners',   ru: 'Одиночки',   ua: 'Одинаки' },
+    r: { en: 'Rulers',   ru: 'Правители',  ua: 'Правителі' },
+    s: { en: 'Shalafi',  ru: 'Шалафи',     ua: 'Шалафі' },
+    n: { en: '',         ru: '',           ua: '' },
+};
+
+// Look up a localized who-panel name; fall back to EN, then the raw code.
+export function raceName(code, lang) {
+    const e = RACE_NAMES[code];
+    if (e == null) return code || '';
+    return e[lang] || e.en;
 }
 
-export const Clans = {
-    'b': 'Ярости',
-    'c': 'Хаос',
-    'e': 'Изгои',
-    'f': 'Цветы',
-    'g': 'Призраки',
-    'h': 'Охотники',
-    'i': 'Захватчики',
-    'k': 'Рыцари',
-    'l': 'Львы',
-    'o': 'Одиночки',
-    'r': 'Правители',
-    's': 'Шалафи', 
-    'n': ''
-}
-
-export const Dnames = {
-    'h': 'Скрыт', 
-    'i': 'Невид', 
-    'w': 'ОНевид', 
-    'f': 'Спрят', 
-    'a': 'Камуф', 
-    'e': 'Зло', 
-    'g': 'Добро', 
-    'u': 'Нежить', 
-    'm': 'Магия', 
-    'o': 'Диагн', 
-    'l': 'Жизнь', 
-    'r': 'Инфра' 
-}
-
-export const Tnames = {
-    'i': 'Невид',
-    'h': 'Скрыт',
-    'F': 'Спрят',
-    'I': 'УНевд',
-    's': 'Подкр',
-    'f': 'Полет',
-    'p': 'Прозр',
-    'm': 'МБлок',
-    'c': 'Камуфл'
-}
-
-export const Enames = { 
-    'r': 'Реген',
-    'h': 'Ускор',
-    'g': 'ГигСил',
-    'l': 'Обуч', 
-    'b': 'Благос',
-    'f': 'Неист',
-    'B': 'Блгсть',
-    'i': 'Вдохн',
-    'c': 'Спокой',
-    'C': 'Концен',
-    'z': 'Берсрк',
-    'w': 'Клич',
-    'F': 'Лес',
-    'm': 'МагФок',
-    't': 'Тигр',
-    'v': 'Вампир'
-}
-
-export const Pnames = { 
-    'z': 'Звезд',
-    's': 'ЗащСвя',
-    'd': 'ТАура',
-    'p': 'ЗащЩит',
-    'e': 'Зло',
-    'g': 'Добро',
-    'm': 'Заклин',
-    'P': 'Молит',
-    'n': 'Негат',
-    'a': 'Броня',
-    'A': 'УлБрон',
-    'S': 'Щит',
-    'D': 'КжДрак',
-    'k': 'КамКж',
-    'r': 'СКамн',
-    'c': 'Холод',
-    'h': 'Жар',
-    'b': 'ЛМыш',
-    'F': 'Немощь',
-    'E': 'Выносл',
-    'R': 'Радуга',
-    'M': 'Мантия',
-    'Z': 'Себат', 
-    'B': 'ДревКж'
-}
-
-export const Mnames = {
-    'b': 'Слеп',
-    'p': 'Яд',
-    'P': 'Чума',
-    'C': 'Гниени',
-    'f': 'ОгФей',
-    'W': 'Очаров',
-    'c': 'Прокл',
-    'w': 'Слабо',
-    's': 'Замедл',
-    'S': 'Крик',
-    'B': 'ЖажКрв',
-    'T': 'Оглуш',
-    'i': 'НетРук',
-    'I': 'Стрела',
-    'j': 'Сосуд',
-    'a': 'Анафем',
-    'e': 'Паут',
-    'E': 'Терн',
-    'r': 'КНож',
-    'n': 'Нервы',
-    'y': 'Укус',
-    'A': 'Шипы',
-    'l': 'Сон'
-}
-
-export const Cnames = {
-    'r': 'Сопрот',
-    's': 'Спелба',
-    'B': 'ЖажКрв',
-    'b': 'Повязк',
-    't': 'Трофей',
-    'T': 'Зрение',
-    'd': 'ОбнЛов',
-    'e': 'Лев',
-    'p': 'Предот',
-    'f': 'Трансф',
-    'g': 'ЗолАур',
-    'h': 'СвщБрн',
-    'S': 'Плащ',
-    'D': 'Доппел',
-    'm': 'Зеркал',
-    'R': 'Рандом',
-    'i': 'Компро',
-    'G': 'Гарбл',
-    'c': 'Конфуз',
-    'M': 'Наруч',
-    'u': 'Повест',
-    'j': 'Тюрьма',
-    'J': 'НеРули',
-    'A': 'АураПр' 
+export function clanName(letter, lang) {
+    const e = CLAN_NAMES[letter];
+    if (e == null) return letter || '';
+    return e[lang] || e.en;
 }

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -34,6 +34,14 @@ export function setLang(lang) {
 
 const STRINGS = {
   en: {
+    // affects panel (title + column headers)
+    'aff.title': 'Affects on you',
+    'aff.pro': 'Prot',
+    'aff.det': 'Detect',
+    'aff.trv': 'Travel',
+    'aff.enh': 'Boost',
+    'aff.mal': 'Curse',
+    'aff.cln': 'Clan',
     // time & weather panel
     'tw.title': 'Weather & time',
     // group panel
@@ -104,6 +112,13 @@ const STRINGS = {
     'ph.example': 'Type a command, e.g.: %s',
   },
   ru: {
+    'aff.title': 'Воздействия на тебе',
+    'aff.pro': 'Защита',
+    'aff.det': 'Обнар',
+    'aff.trv': 'Трансп',
+    'aff.enh': 'Усилен',
+    'aff.mal': 'Отриц',
+    'aff.cln': 'Клан',
     'tw.title': 'Погода и время',
     'grp.title': 'Группа',
     'grp.name': 'Имя',
@@ -161,6 +176,13 @@ const STRINGS = {
     'ph.example': 'Введи команду, например: %s',
   },
   ua: {
+    'aff.title': 'Впливи на тебе',
+    'aff.pro': 'Захист',
+    'aff.det': 'Виявл',
+    'aff.trv': 'Трансп',
+    'aff.enh': 'Підсил',
+    'aff.mal': 'Негат',
+    'aff.cln': 'Клан',
     'tw.title': 'Погода і час',
     'grp.title': 'Група',
     'grp.name': 'Імʼя',


### PR DESCRIPTION
Round 3 of the client i18n work.

## who-panel race & clan names (trilingual)
The who panel showed race/clan names in Russian only. Now trilingual (EN/RU/UA):
- `windowletsConstants.js` gains `RACE_NAMES`/`CLAN_NAMES` (keyed by the 2-letter/1-letter code the server sends) + `raceName(code, lang)` / `clanName(code, lang)` helpers (fall back EN → raw code).
- `whoItem` threads the display language in.
- EN forms = the engine's own `<nameWho>` (races/*.xml); UA from `RACES_UA.md` and `clans/*.xml`; terse (≤8 chars) to fit the column. Verified against game data (e.g. `ma`=Mawg/Псюрень, `ro`=Rockseer not "roxir", the four Giant types).

⚠️ **One flag:** githyanki UA — used `Гітіанки` per the authoritative `RACES_UA.md` + `githyanki.xml`. A memory note had `гітʼянкі` (apostrophe, different ending); the game-data form wins here, but worth reconciling.

## affect-panel cleanup
- Migrated the inline `HEADERS` map onto the central i18n helper (`aff.*` keys) now that `i18n.js` exists (the code comment asked for exactly this).
- Deleted the dead legacy path: the `{a,z}` char-dict branch + the six unused `Dnames/Tnames/Enames/Pnames/Mnames/Cnames` dicts — the server ships the dynamic `[{n,d}]` format post-reboot, so they're gone (tree-shaking also shrank the bundle).
- Added a stable `storageKey="affects"` so collapsed state stops keying off the now-dynamic localized title.

Validated with `vite build` (1035 modules, clean).