### PR TITLE
manip: handle [look=…] exit-keyword tags [HOLD — deploy before code #652 reboot]

### DIFF
--- a/src/manip.js
+++ b/src/manip.js
@@ -95,6 +95,23 @@ function manipParseAndReplace(span) {
     }
   );
 
+  // Replace exit-keyword placeholders [look=door,see=door] with a clickable
+  // <span> that sends "look door" -- room exits resolve via 'look', not 'read'.
+  html = html.replace(
+    /\[look=([^,]{1,200}),see=([^\]]{1,30})]/gi,
+    function (match, p1, p2, string) {
+      return (
+        '<span class="manip-cmd manip-ed" data-action="look ' +
+        p1 +
+        '" data-echo="смотреть ' +
+        p2 +
+        '">' +
+        p2 +
+        '</span>'
+      );
+    }
+  );
+
   // Replace random commands with data-action span.
   html = html.replace(
     /\[cmd=([^,]{1,200}),see=([^\]]{1,50}),nonce=(.{8})]/gi,


### PR DESCRIPTION
Client half of the exit-marker fix. The server (dreamland_code #652) will emit `[look=X,see=Y]` for `(door)` markers that name a visible room exit; this renders them as a clickable span sending `look X`, mirroring the existing `[read=…]` handler.

Forward-compatible: harmless before the server change (no `[look=…]` is emitted yet).

**Merge order:** this client PR should deploy **before** code #652 goes live, so the server never emits a `[look=…]` tag the client can't render. Both held until the movement l10n canary is validated.