### PR TITLE
Combat UI accent + persist display language

### DIFF
--- a/src/combatui.js
+++ b/src/combatui.js
@@ -1,0 +1,18 @@
+import $ from 'jquery';
+
+// Combat UI accent: while the player is fighting, paint the client red -- a red
+// stroke on the command input and a faint red inner glow around the terminal --
+// so it's obvious at a glance that combat is live (matters most for players with
+// fightspam off, where a quiet round prints little or nothing).
+//
+// Driven by window.mudprompt.fight (>0 while fighting), which prompt.js keeps
+// current from every web prompt (interprethandler webPrompt -> prompt.fight).
+// We only toggle a body class; the styling lives in main.css (body.mud-fighting)
+// and auto-reverts the instant combat ends (fight drops back to 0). Imported
+// after ./prompt in main.js so window.mudprompt is already updated when we read it.
+$(function () {
+  $('#rpc-events').on('rpc-prompt', function () {
+    const fighting = !!(window.mudprompt && window.mudprompt.fight > 0);
+    document.body.classList.toggle('mud-fighting', fighting);
+  });
+});

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -15,11 +15,30 @@ import $ from 'jquery';
 // Only UI CHROME lives here. Game text (room/act/affect labels) is localized on the
 // server and arrives already in the player's language.
 
-let currentLang = 'en';
+// Seed from the browser's remembered choice so the UI chrome opens in the right
+// language instead of flashing English until the first prompt arrives. The
+// server still overrides it on every prompt (below), and we persist that value
+// back so the memory survives reloads and follows an in-game `config lang`.
+function readSavedLang() {
+  try {
+    return localStorage.getItem('mudjs.lang');
+  } catch (e) {
+    return null; // localStorage unavailable (private mode) -- fall back to EN
+  }
+}
+
+let currentLang = readSavedLang() || 'en';
 
 $(function () {
   $('#rpc-events').on('rpc-prompt', function (e, b) {
-    if (b && b.lang != null) currentLang = b.lang;
+    if (b && b.lang != null) {
+      currentLang = b.lang;
+      try {
+        localStorage.setItem('mudjs.lang', b.lang);
+      } catch (e2) {
+        /* ignore: private mode / storage disabled */
+      }
+    }
   });
 });
 

--- a/src/main.css
+++ b/src/main.css
@@ -772,3 +772,22 @@ header.MuiPaper-root.MuiAppBar-root {
     display: none !important;
   }
 }
+
+/* --- Combat UI accent -------------------------------------------------------
+ * src/combatui.js toggles body.mud-fighting while the player is fighting.
+ * Paint a red stroke on the command input and a faint red inner glow around the
+ * terminal so it's obvious combat is live; both fade in/out and revert the
+ * instant combat ends. Placed last so it overrides the cyan focus stroke
+ * (higher specificity than form#input:focus-within). The input border only
+ * exists on big screens, so the red stroke shows there; the glow shows on all.
+ */
+.terminal-wrap,
+form#input {
+  transition: box-shadow 0.35s ease, border-color 0.35s ease;
+}
+body.mud-fighting .terminal-wrap {
+  box-shadow: inset 0 0 38px 2px rgba(204, 0, 0, 0.3);
+}
+body.mud-fighting form#input {
+  border-color: #cc0000;
+}

--- a/src/main.js
+++ b/src/main.js
@@ -10,6 +10,7 @@ import './notify';
 import './input';
 import './settings';
 import './prompt';
+import './combatui';
 import './textedit';
 import './cs';
 


### PR DESCRIPTION
**Combat UI:** while fighting (`window.mudprompt.fight > 0`), toggle `body.mud-fighting` — red stroke on the command input + faint red inner glow on the terminal, fading in/out, auto-reverting when combat ends. New `src/combatui.js` (imported after `./prompt`) + CSS. Makes live combat obvious at a glance (esp. fightspam-off).

**Persist language:** seed UI language from a remembered `localStorage` value (no more English flash before the first prompt) and save the server's lang on every prompt so it survives reloads + follows in-game `config lang`.

Part of the fighting-UX + language-sync work; the 2-way lang push (browser -> server) follows in a second PR once the selector placement is settled.