### PR TITLE
Combat UI: bigger, softer red glow toward terminal centre

### DIFF
--- a/src/main.css
+++ b/src/main.css
@@ -786,7 +786,12 @@ form#input {
   transition: box-shadow 0.35s ease, border-color 0.35s ease;
 }
 body.mud-fighting .terminal-wrap {
-  box-shadow: inset 0 0 38px 2px rgba(204, 0, 0, 0.3);
+  /* Big, soft red vignette that reaches well toward the centre: a broad deep
+     inset shadow (large blur + spread) for the diffuse glow, plus a tighter one
+     to keep the edge defined. */
+  box-shadow:
+    inset 0 0 200px 48px rgba(204, 0, 0, 0.24),
+    inset 0 0 70px 0 rgba(204, 0, 0, 0.32);
 }
 body.mud-fighting form#input {
   border-color: #cc0000;


### PR DESCRIPTION
Bump the fighting inner-glow from a thin edge to a broad vignette reaching toward the centre (stacked inset shadows: 200px/48px diffuse + 70px edge). Follow-up on #134.