### PR TITLE
Combat UI: let glow show across terminal (drop redundant .terminal bg)

### DIFF
--- a/src/main.css
+++ b/src/main.css
@@ -50,7 +50,10 @@ body {
 .terminal {
   font-family: 'Roboto Mono', monospace;
   font-size: 1.3em;
-  background-color: #121212;
+  /* No background here: the dark canvas lives on the .terminal-wrap window
+     container. A background on this content layer would sit ON TOP of the
+     wrap and hide its inset combat glow (it's the same #121212, so removing
+     it is visually identical in the normal state). */
   color: #d3d7cf;
   white-space: pre-wrap;
   /* Anchor the 80-column guide and let it span the full visible height even


### PR DESCRIPTION
The `.terminal` content layer painted its own `#121212` bg on top of `.terminal-wrap`, hiding the wrap's inset combat glow everywhere but the padding strip (looked cut at ~20-30px). Drop the redundant bg from `.terminal` (same colour as the wrap, normal state unchanged); the glow now reaches across the whole window. Follow-up on #136.