### PR TITLE
Combat UI: pulse the red glow like a heartbeat

### DIFF
--- a/src/main.css
+++ b/src/main.css
@@ -788,12 +788,40 @@ header.MuiPaper-root.MuiAppBar-root {
 form#input {
   transition: box-shadow 0.35s ease, border-color 0.35s ease;
 }
+/* Heartbeat: the red vignette pulses while fighting -- a fast snap outward (no
+   ease, ~14% of the cycle so it feels like a quick beat) then a slow eased
+   collapse back (diastole). Per-keyframe animation-timing-function sets the feel
+   of each segment: linear on the grow, ease-out on the collapse. */
+@keyframes combat-heartbeat {
+  0% {
+    box-shadow:
+      inset 0 0 95px 0 rgba(204, 0, 0, 0.13),
+      inset 0 0 190px 0 rgba(204, 0, 0, 0.06);
+    animation-timing-function: linear; /* grow: no ease, snappy */
+  }
+  14% {
+    box-shadow:
+      inset 0 0 165px 0 rgba(204, 0, 0, 0.24),
+      inset 0 0 330px 0 rgba(204, 0, 0, 0.12);
+    animation-timing-function: ease-out; /* collapse: eased, slow */
+  }
+  100% {
+    box-shadow:
+      inset 0 0 95px 0 rgba(204, 0, 0, 0.13),
+      inset 0 0 190px 0 rgba(204, 0, 0, 0.06);
+  }
+}
 body.mud-fighting .terminal-wrap {
-  /* Big, soft red vignette reaching toward the centre: a tighter stronger inset
-     glow (150px @ 20%) layered over a broad faint one (300px @ 10%). */
-  box-shadow:
-    inset 0 0 150px 0 rgba(204, 0, 0, 0.2),
-    inset 0 0 300px 0 rgba(204, 0, 0, 0.1);
+  animation: combat-heartbeat 1.15s infinite;
+}
+/* Respect reduced-motion: hold a steady mid-strength glow instead of pulsing. */
+@media (prefers-reduced-motion: reduce) {
+  body.mud-fighting .terminal-wrap {
+    animation: none;
+    box-shadow:
+      inset 0 0 150px 0 rgba(204, 0, 0, 0.2),
+      inset 0 0 300px 0 rgba(204, 0, 0, 0.1);
+  }
 }
 body.mud-fighting form#input {
   border-color: #cc0000;


### PR DESCRIPTION
Glow now beats while fighting: fast snap outward (linear, ~14% of cycle -> growing feels quick) + slow eased collapse, ~1.15s/beat, looping. Per-keyframe timing-function per phase. prefers-reduced-motion -> steady glow. Follow-up on #137.