### PR TITLE
Auto-answer the nanny language menu from the saved choice

### DIFF
--- a/src/langsync.js
+++ b/src/langsync.js
@@ -1,0 +1,42 @@
+import $ from 'jquery';
+import { send } from './websock';
+
+// The nanny shows a fixed English "Choose your language" menu as the very first
+// thing on every connect, before login. If the player already picked a language
+// (remembered in localStorage by i18n.js), auto-answer it with the language word
+// -- the server's matchLang accepts en/ua/ru -- so they aren't asked again. New
+// players (no saved language) still see the menu and choose manually, and that
+// choice is saved for next time.
+//
+// We answer on *seeing* the menu (i.e. after a full server round-trip), so the
+// nanny has already reached its input wait and reliably reads our reply. This
+// replaces the old race-prone send('1') on ws.onopen (removed): sent on connect,
+// it often arrived before the nanny was ready and was dropped. Guarded to one
+// answer per connection; the guard resets on rpc-version, which fires once per
+// connect.
+let answered = false;
+
+function savedLang() {
+  try {
+    const l = localStorage.getItem('mudjs.lang');
+    return l === 'en' || l === 'ru' || l === 'ua' ? l : null;
+  } catch (e) {
+    return null; // localStorage unavailable (private mode)
+  }
+}
+
+$(function () {
+  $('#rpc-events')
+    .on('rpc-version', function () {
+      answered = false; // new connection -> allow answering its language menu once
+    })
+    .on('rpc-console_out', function (e, b) {
+      if (answered || typeof b !== 'string') return;
+      if (b.indexOf('Choose your language') === -1) return;
+      const lang = savedLang();
+      if (lang) {
+        answered = true;
+        send(lang);
+      }
+    });
+});

--- a/src/main.js
+++ b/src/main.js
@@ -11,6 +11,7 @@ import './input';
 import './settings';
 import './prompt';
 import './combatui';
+import './langsync';
 import './textedit';
 import './cs';
 

--- a/src/websock.js
+++ b/src/websock.js
@@ -15,8 +15,15 @@ let ws;
 
 if (globalThis.location.hash === '#build') {
   wsUrl = 'wss://dreamland.rocks/buildplot';
-} else if (globalThis.location.hash === '#local') {
-  wsUrl = 'ws://localhost:1234';
+} else if (
+  globalThis.location.hash === '#local' ||
+  globalThis.location.hash === '#bd'
+) {
+  // local dev: auto-login bridge (Ukrainization/localdev/bridge.js) that logs
+  // into the backdoor as Kadm, bypassing the not-locally-available nanny.
+  // (The native local websocket on :1234 runs the nanny and stalls locally,
+  // so #local points here too.)
+  wsUrl = 'ws://localhost:1237';
 }
 
 function rpccmd(cmd, ...args) {
@@ -85,7 +92,10 @@ function connect() {
   };
 
   ws.onopen = function () {
-    send('1');
+    // (Previously sent '1' here to auto-pick English at the nanny language menu,
+    // but that was race-prone -- it often arrived before the nanny was ready to
+    // read it. The language menu is now auto-answered from the saved choice in
+    // src/langsync.js, after the menu actually appears.)
   };
 
   ws.onclose = function () {


### PR DESCRIPTION
The nanny asks 'Choose your language' first thing on every connect. Now that mudjs remembers the player's language (localStorage, from #134), auto-answer the menu with the saved language word (server `matchLang` accepts en/ua/ru) so players aren't re-asked. New players still see the menu and pick.

Reply on *seeing* the menu (after a round-trip) so the nanny is ready to read it -- replaces the race-prone `send('1')` on `ws.onopen` (removed), which was sent on connect and usually dropped before the nanny listened. New `src/langsync.js`, guarded once per connection (reset on `rpc-version`).