### PR TITLE
Restore the codepage-select send('1') on connect (koi8-r)

### DIFF
--- a/src/langsync.js
+++ b/src/langsync.js
@@ -9,11 +9,10 @@ import { send } from './websock';
 // choice is saved for next time.
 //
 // We answer on *seeing* the menu (i.e. after a full server round-trip), so the
-// nanny has already reached its input wait and reliably reads our reply. This
-// replaces the old race-prone send('1') on ws.onopen (removed): sent on connect,
-// it often arrived before the nanny was ready and was dropped. Guarded to one
-// answer per connection; the guard resets on rpc-version, which fires once per
-// connect.
+// nanny has already reached its input wait and reliably reads our reply. This is
+// the LANGUAGE menu only; the earlier codepage menu is answered separately by the
+// send('1') on ws.onopen (koi8-r). Guarded to one answer per connection; the
+// guard resets on rpc-version, which fires once per connect.
 let answered = false;
 
 function savedLang() {

--- a/src/websock.js
+++ b/src/websock.js
@@ -92,10 +92,12 @@ function connect() {
   };
 
   ws.onopen = function () {
-    // (Previously sent '1' here to auto-pick English at the nanny language menu,
-    // but that was race-prone -- it often arrived before the nanny was ready to
-    // read it. The language menu is now auto-answered from the saved choice in
-    // src/langsync.js, after the menu actually appears.)
+    // Answer the server's very first prompt -- the codepage menu -- with '1' =
+    // koi8-r, which is the encoding this client decodes (see telnet.js koi2utf).
+    // REQUIRED: without it the session stays on the wrong codepage and text is
+    // garbled. This is NOT the language menu (that comes next and is handled by
+    // src/langsync.js).
+    send('1');
   };
 
   ws.onclose = function () {


### PR DESCRIPTION
#139 wrongly removed `send('1')` on `ws.onopen` as a 'race-prone language answer'. It actually answers the server's FIRST prompt -- the **codepage menu** -- selecting koi8-r, the encoding mudjs decodes (`telnet.js` koi2utf). Without it text is garbled. It's a different prompt from the language menu (still handled by `langsync.js`), so both coexist. Restore it.