### PR TITLE
Fix the mobile layout clipping the input bar and stat bars

### DIFF
--- a/src/app.jsx
+++ b/src/app.jsx
@@ -94,8 +94,15 @@ export default function App() {
       display="flex"
       flexDirection="column"
       sx={{
-        height: '100vh',
-        width: '100vw',
+        // Percent, not 100vh/100vw. On mobile Chromium `100vh` is frozen to the
+        // large viewport (browser chrome retracted), while the #root percentage
+        // chain tracks the currently visible one -- so a 100vh box overflows
+        // #root by the height of the visible URL bar, and #root's overflow:hidden
+        // clips that slice away with no way to scroll to it. The clipped slice is
+        // the bottom of the layout: the command input and the Stats bars.
+        // Percent fits #root exactly, whatever the browser does with its chrome.
+        height: '100%',
+        width: '100%',
         overflow: 'hidden',
       }}
     >


### PR DESCRIPTION
## Symptom

On mobile the client shows no command input and no HP/mana/moves bars at all -- the entire bottom slice of the layout is missing from the moment the page loads. Reproduced on Android with both Brave and Samsung Internet. Desktop is fine.

## Root cause

The DOM height chain is:

| element | height | source |
|---|---|---|
| `html, body` | `100%` | `src/main.css:5` |
| `#root` | `100%` + `overflow: hidden` | `src/main.css:26` |
| App root `<Box>` | `100vh` / `100vw` | `src/app.jsx:97` |

On mobile Chromium those last two are different numbers. The percentage chain resolves against the *currently visible* viewport and shrinks while the URL bar is on screen; `100vh` is frozen to the *large* viewport, i.e. the height with the browser chrome retracted.

So the root Box overflows `#root` by exactly the height of the visible browser chrome, and `#root`'s `overflow: hidden` clips that bottom slice away. There is nothing to scroll, so it is unreachable. The clipped slice is the bottom of the layout: `<CmdInput />` at the foot of the terminal pane and `<Stats />` below it. Samsung Internet keeps a bottom toolbar as well, which makes the cut larger.

Introduced in 2c9bc52 (Vite/MUI migration), so this is long-standing rather than a regression from the recent combat-UI work.

## Fix

Size the root Box in percent. It then fits `#root` exactly whatever the browser does with its chrome, on every platform.

Desktop rendering is unchanged, with one incidental improvement: `100vw` includes the vertical scrollbar width and caused a few pixels of horizontal overflow, which percent also removes.

## Testing

Verified the build locally via the pre-push hook. Mobile behaviour needs a hard refresh on an Android device after the drone deploy.