### PR TITLE
Echo clickable-link commands in the player's language

### DIFF
--- a/src/i18n.js
+++ b/src/i18n.js
@@ -129,6 +129,15 @@ const STRINGS = {
     'term.historyLoaded': 'CHAT HISTORY LOADED',
     // input placeholder hint ("%s" = example command)
     'ph.example': 'Type a command, e.g.: %s',
+    // Echo verbs for clickable links. The command SENT is always the canonical
+    // English one; these are only what gets echoed into the player's own
+    // scrollback, so they follow the display language the way a typed command
+    // would. Values mirror <name l="..."> in dreamland_world/commands.
+    'cmd.read': 'read',
+    'cmd.look': 'look',
+    'cmd.help': 'help',
+    'cmd.glist': 'glist',
+    'cmd.run': 'run',
   },
   ru: {
     'aff.title': 'Воздействия на тебе',
@@ -193,6 +202,11 @@ const STRINGS = {
     'ov.unread': 'Непрочитано: %d',
     'term.historyLoaded': 'ИСТОРИЯ ЧАТА ЗАГРУЖЕНА',
     'ph.example': 'Введи команду, например: %s',
+    'cmd.read': 'читать',
+    'cmd.look': 'смотреть',
+    'cmd.help': 'помощь',
+    'cmd.glist': 'группаумений',
+    'cmd.run': 'бежать',
   },
   ua: {
     'aff.title': 'Впливи на тебе',
@@ -257,6 +271,11 @@ const STRINGS = {
     'ov.unread': 'Непрочитано: %d',
     'term.historyLoaded': 'ІСТОРІЯ ЧАТУ ЗАВАНТАЖЕНА',
     'ph.example': 'Введи команду, наприклад: %s',
+    'cmd.read': 'читати',
+    'cmd.look': 'дивитися',
+    'cmd.help': 'допомога',
+    'cmd.glist': 'групавмінь',
+    'cmd.run': 'бігти',
   },
 };
 

--- a/src/manip.js
+++ b/src/manip.js
@@ -2,6 +2,7 @@ import $ from 'jquery';
 import areasJson from './data/areas.json';
 import { send, ws } from './websock.js';
 import { echo } from './input.js';
+import { t } from './i18n.js';
 
 // Create the list of all possible area file names (without ".are" bit).
 const areas = areasJson.map(a => a.file.replace('.are', ''));
@@ -86,7 +87,7 @@ function manipParseAndReplace(span) {
       return (
         '<span class="manip-cmd manip-ed" data-action="read \'' +
         p1 +
-        '\'" data-echo="читать ' +
+        '\'" data-echo="' + t('cmd.read') + ' ' +
         p2 +
         '">' +
         p2 +
@@ -103,7 +104,7 @@ function manipParseAndReplace(span) {
       return (
         '<span class="manip-cmd manip-ed" data-action="look ' +
         p1 +
-        '" data-echo="смотреть ' +
+        '" data-echo="' + t('cmd.look') + ' ' +
         p2 +
         '">' +
         p2 +
@@ -225,7 +226,7 @@ function manipParseAndReplace(span) {
           .addClass('manip-cmd')
           .addClass('manip-link')
           .attr('data-action', 'help ' + id)
-          .attr('data-echo', 'справка ' + id)
+          .attr('data-echo', t('cmd.help') + ' ' + id)
           .append(label)
           .get(0).outerHTML +
         '&nbsp;'.repeat(spaceEnd);
@@ -241,7 +242,7 @@ function manipParseAndReplace(span) {
       var result = $('<span/>')
         .addClass('manip-cmd')
         .attr('data-action', 'glist ' + article.text())
-        .attr('data-echo', 'группаумен ' + article.text())
+        .attr('data-echo', t('cmd.glist') + ' ' + article.text())
         .append(article);
       return result;
     });
@@ -256,7 +257,7 @@ function manipParseAndReplace(span) {
         .addClass('manip-cmd')
         .addClass('manip-speedwalk')
         .attr('data-action', 'run ' + article.text())
-        .attr('data-echo', 'бежать ' + article.text())
+        .attr('data-echo', t('cmd.run') + ' ' + article.text())
         .append(article);
       return result;
     });


### PR DESCRIPTION
Reported from an English playthrough: clicking a help link printed

```
справка Moehewa
```

into the player's own scrollback.

## What was wrong

Five link handlers in `manip.js` hard-coded a Russian verb in `data-echo`:

| tag | action sent | echo was |
|---|---|---|
| `[read=…]` | `read '…'` | `читать` |
| `[look=…]` | `look …` | `смотреть` |
| `<hh>` | `help <id>` | `справка` |
| `<hg>` | `glist <group>` | `группаумен` |
| `<hs>` | `run <sw>` | `бежать` |

Only the echo was affected — `data-action` always carried the canonical English command, so the links themselves worked. They just narrated themselves in Russian to everyone.

## Fix

The verbs now come from the existing `i18n.js` table, so the echo follows the display language exactly as a typed command would look. Values mirror `<name l="...">` in `dreamland_world/commands`, which incidentally corrects two inaccuracies carried by the old literals: `help` echoed *справка* where the command's Russian name is *помощь*, and `glist` echoed a truncated *группаумен* rather than *группаумений*.

`npm run build` passes.