### PR TITLE
Point the zone map button at the map page

### DIFF
--- a/src/i18n.js
+++ b/src/i18n.js
@@ -110,6 +110,7 @@ const STRINGS = {
     'help.title': 'Help search',
     'help.placeholder': 'Enter a keyword',
     'help.notFound': 'No help found',
+    'help.openMap': 'open the map',
     // vital bars
     'st.health': 'Health',
     'st.enemy': 'Enemy',
@@ -188,6 +189,7 @@ const STRINGS = {
     'help.title': 'Поиск по справке',
     'help.placeholder': 'Введи ключевое слово',
     'help.notFound': 'Справка не найдена',
+    'help.openMap': 'открыть карту',
     'st.health': 'Здоровье',
     'st.enemy': 'Противник',
     'st.mana': 'Мана',
@@ -257,6 +259,7 @@ const STRINGS = {
     'help.title': 'Пошук у довідці',
     'help.placeholder': 'Введи ключове слово',
     'help.notFound': 'Довідку не знайдено',
+    'help.openMap': 'відкрити мапу',
     'st.health': 'Здоровʼя',
     'st.enemy': 'Ворог',
     'st.mana': 'Мана',

--- a/src/manip.js
+++ b/src/manip.js
@@ -1,11 +1,7 @@
 import $ from 'jquery';
-import areasJson from './data/areas.json';
 import { send, ws } from './websock.js';
 import { echo } from './input.js';
 import { t } from './i18n.js';
-
-// Create the list of all possible area file names (without ".are" bit).
-const areas = areasJson.map(a => a.file.replace('.are', ''));
 
 $(document).ready(function () {
   // Control panel buttons.
@@ -62,16 +58,23 @@ function colorParseAndReplace(span) {
 }
 
 function manipParseAndReplace(span) {
-  // Replace placeholders [map=filename.are] with buttons that open a map,
-  // or with an empty string, if area is not found in the areas.json.
+  /* Replace placeholders [map=filename.are] with a link to the zone's page on
+   * the maps site. It used to point at /maps/<file>.html -- the old per-zone
+   * static page, on the pre-redesign layout -- and was gated on a bundled
+   * areas.json that had gone stale at 129 of the game's 158 zones, so the ~29
+   * newest zones silently rendered no link at all. The marker only ever
+   * appears in a zone article, and every zone the game has is on the map page,
+   * so there is nothing left to gate on. */
   var html = span
     .html()
     .replace(/\[map=([-0-9a-z_]{1,15})\.are\]/g, function (match, p1, string) {
-      if (areas.indexOf(p1) === -1) return '';
       return (
-        '<a class="btn btn-sm btn-outline-info btn-orange" href="https://dreamland.rocks/maps/' +
+        '<a class="btn btn-sm btn-outline-info btn-orange" ' +
+        'href="https://dreamland.rocks/maps.html#' +
         p1 +
-        '.html" target=_blank>открыть карту</a>'
+        '" target=_blank>' +
+        t('help.openMap') +
+        '</a>'
       );
     });
 


### PR DESCRIPTION
The `[map=<file>.are]` marker a zone help article carries became a link to `https://dreamland.rocks/maps/<file>.html` -- the *pre-redesign* per-zone static page -- and only when the file was found in the bundled `data/areas.json`. That file has gone stale at 129 entries against the game's 158 zones, so for the ~29 newest ones the marker was replaced with an empty string and the player got no link at all.

Now it links to `maps.html#<file>` (the interactive map, which carries all 156 non-system zones) with no gate: the marker only ever appears in a zone article, and every zone the game has is on that page.

The label was a hardcoded `открыть карту` for English and Ukrainian readers too; it now comes from `i18n.js` (`help.openMap`) like the rest of the UI chrome. `data/areas.json` is no longer imported by `manip.js`.

Server side: dreamland-mud/dreamland_code#869 moves the marker into the article's metadata bullet list. Site side: dreamland-mud/dreamland_web#197.