### PR TITLE
Come straight back when the socket dies

### DIFF
--- a/src/websock.js
+++ b/src/websock.js
@@ -73,12 +73,68 @@ $(document).ready(function () {
             ').\n' +
             'Обнови страницу, если не поможет - почисти кеши.\u001b[0;37m\n'
         );
+        // Drop the token first: retrying would just meet the same mismatch,
+        // silently, forever. The player needs to see the message and reload.
+        setResumeToken(null);
         ws.close();
       }
 
       ws.nonce = nonce;
     });
 });
+
+/* Session resume.
+ *
+ * A phone suspends this tab a second or two after the player switches apps,
+ * and the socket dies with it -- nothing here or on the server can stop that.
+ * What it can do is come straight back: the server puts a short-lived resume
+ * token in every prompt, and presenting it on the next connection drops us
+ * back into the same character with no login at all.
+ *
+ * sessionStorage, not localStorage: the token stands in for a password while
+ * it lives, so it dies with the tab instead of sitting on disk.
+ */
+const RESUME_KEY = 'mudjs.resume';
+const RECONNECT_MAX = 15000;
+let reconnectTimer = null;
+let reconnectDelay = 0;
+
+function resumeToken() {
+  try {
+    return sessionStorage.getItem(RESUME_KEY);
+  } catch (e) {
+    return null; // private mode / storage disabled: fall back to logging in
+  }
+}
+
+function setResumeToken(token) {
+  try {
+    if (token) sessionStorage.setItem(RESUME_KEY, token);
+    else sessionStorage.removeItem(RESUME_KEY);
+  } catch (e) {
+    /* ignore: nothing to do if storage is unavailable */
+  }
+}
+
+function wsAlive() {
+  return (
+    ws &&
+    (ws.readyState === WebSocket.CONNECTING || ws.readyState === WebSocket.OPEN)
+  );
+}
+
+function scheduleReconnect() {
+  if (reconnectTimer) return;
+
+  // The first retry is immediate: the common case is a tab waking up, where
+  // the network is already back and the only thing missing is the socket.
+  const delay = reconnectDelay;
+  reconnectDelay = Math.min(delay ? delay * 2 : 500, RECONNECT_MAX);
+  reconnectTimer = setTimeout(function () {
+    reconnectTimer = null;
+    connect();
+  }, delay);
+}
 
 function connect() {
   ws = new WebSocket(wsUrl, ['binary']);
@@ -92,6 +148,16 @@ function connect() {
   };
 
   ws.onopen = function () {
+    reconnectDelay = 0;
+
+    /* Holding a token, say nothing else until the server has ruled on it: if
+     * the resume takes, the codepage answer below would land in the game as a
+     * typed command. resume_ok / resume_failed decides which path we are on. */
+    if (resumeToken()) {
+      rpccmd('resume', resumeToken());
+      return;
+    }
+
     // Answer the server's very first prompt -- the codepage menu -- with '1' =
     // koi8-r, which is the encoding this client decodes (see telnet.js koi2utf).
     // REQUIRED: without it the session stays on the wrong codepage and text is
@@ -101,15 +167,59 @@ function connect() {
   };
 
   ws.onclose = function () {
-    process(
-      '\u001b[1;31m#################### DISCONNECTED ####################\u001b[0;37m\n'
-    );
     ws = null;
     store.dispatch(onDisconnected());
+
+    /* Only say DISCONNECTED when there is nothing left to try. A token means a
+     * silent retry instead, which is the whole point for a backgrounded phone:
+     * the player comes back to their game, not to a red banner. */
+    if (!resumeToken()) {
+      process(
+        '\u001b[1;31m#################### DISCONNECTED ####################\u001b[0;37m\n'
+      );
+      return;
+    }
+
+    scheduleReconnect();
   };
 
-  process('Connecting....\n');
+  // Silent while resuming: a backgrounded phone can go through several
+  // attempts, and each one announcing itself is exactly the noise this feature
+  // exists to remove.
+  if (!resumeToken()) process('Connecting....\n');
   store.dispatch(onConnected());
 }
+
+$(document).ready(function () {
+  $('#rpc-events')
+    .on('rpc-prompt', function (e, b) {
+      if (b && b.resume) setResumeToken(b.resume);
+    })
+    .on('rpc-resume_ok', function () {
+      // Straight back into the character: no banner, no login, and the
+      // scrollback in this tab is still the one the player left.
+      reconnectDelay = 0;
+    })
+    .on('rpc-resume_failed', function () {
+      // Spent, expired, or the character has left the world. Ordinary session.
+      setResumeToken(null);
+      send('1');
+    });
+
+  /* A suspended tab often learns its socket is dead only once it wakes, so do
+   * not wait for onclose to fire -- check on the way back in. */
+  document.addEventListener('visibilitychange', function () {
+    if (document.visibilityState !== 'visible') return;
+    if (wsAlive() || !resumeToken()) return;
+    reconnectDelay = 0;
+    scheduleReconnect();
+  });
+
+  window.addEventListener('online', function () {
+    if (wsAlive() || !resumeToken()) return;
+    reconnectDelay = 0;
+    scheduleReconnect();
+  });
+});
 
 export { send, rpccmd, connect, ws };


### PR DESCRIPTION
Client half of dreamland-mud/dreamland_code#871.

`ws.onclose` printed `DISCONNECTED`, set `ws = null` and stopped. There was no reconnect and no keepalive of any kind, so a phone that suspended the tab for two seconds cost the player a page reload and a fresh login.

Now:

- the resume token the server puts in every prompt is kept in **sessionStorage** (not localStorage -- it stands in for a password while it lives, so it should die with the tab) and presented on the next connection, which drops the player back into the same character with no login;
- retries are **silent** -- no banner, no `Connecting....` per attempt. A silent return is the whole point; the scrollback in the tab is still the one the player left;
- the first retry is **immediate**, then 500ms doubling to 15s. The common case is a tab waking up with the network already back;
- `visibilitychange` and `online` reconnect without waiting for `onclose`, which a suspended tab often reports only once it wakes;
- `DISCONNECTED` still appears when there is genuinely nothing left to try (no token, or the token was refused);
- a **version mismatch clears the token before closing**, so a stale client shows the "reload the page" message instead of silently retrying into the same mismatch forever.

Handshake order is explicit rather than racy: holding a token the client sends `resume` and says nothing else until the server answers `resume_ok` or `resume_failed`. Sending the codepage `1` first would land in the game as a typed command once the resume took.