### PR TITLE
Swap the button panel for combat commands during a fight

### DIFF
--- a/src/components/windowletsPanel/commandButtons.jsx
+++ b/src/components/windowletsPanel/commandButtons.jsx
@@ -3,44 +3,101 @@ import { useSelector } from 'react-redux'
 import PanelItem from './panelItem'
 import { t } from '../../i18n'
 
-// const ButtonItem = (button) => {
-//     return (
-//         <button type="button" className="btn btn-ctrl-panel" data-action={button.action} >{button.title}</button>
-//     )
-//     // return null
-// }
+// What each button actually sends. The interpreter resolves command names in
+// every language it knows, so a button speaks the player's own: manip.js echoes
+// data-action verbatim into the scrollback, and a Russian word landing in an
+// English player's log reads like a glitch. Source of truth for every word
+// below: <name>/<aliases> in dreamland_world/commands.
+const WORDS = {
+  look: { en: 'look', ru: 'смотреть', ua: 'дивитися' },
+  inv: { en: 'inventory', ru: 'инвентарь', ua: 'інвентар' },
+  equip: { en: 'equipment', ru: 'снаряжение', ua: 'спорядження' },
+  // 'score', not 'oscore': the compact modern sheet, not the classic layout.
+  score: { en: 'score', ru: 'счет', ua: 'рахунок' },
+  recall: { en: 'recall', ru: 'возврат', ua: 'повернення' },
+  flee: { en: 'flee', ru: 'сбежать', ua: 'втекти' },
+  practice: { en: 'practice', ru: 'практиковать', ua: 'практикувати' },
+  magic: { en: 'skills spells', ru: 'умения заклинания', ua: 'вміння заклинання' },
+  skills: { en: 'skills skills', ru: 'умения навыки', ua: 'вміння навички' },
+  quests: { en: 'quest', ru: 'задания', ua: 'завдання' },
+  commands: { en: 'commands', ru: 'команды', ua: 'команди' },
+  quit: { en: 'quit', ru: 'конец', ua: 'кінець' },
+}
+
+function word(key, lang) {
+  const w = WORDS[key]
+  return (w && (w[lang] || w.en)) || key
+}
+
+function capitalize(s) {
+  return s ? s.charAt(0).toUpperCase() + s.slice(1) : s
+}
+
+function Btn({ action, label, confirm, combat }) {
+  return (
+    <button
+      type="button"
+      className={'btn btn-ctrl-panel' + (combat ? ' btn-combat' : '')}
+      data-action={action}
+      data-confirm={confirm}
+    >
+      {label}
+    </button>
+  )
+}
 
 export default function CommandButtons() {
-    const prompt = useSelector(state => state.prompt);
+  const prompt = useSelector(state => state.prompt)
 
-    if(!prompt)
-        return null;
+  if (!prompt) return null
 
-    // data-action stays in Russian: it is the command sent to the engine, which
-    // resolves RU aliases regardless of the player's display language. Only the
-    // visible label is localized.
-    const l = prompt.lang;
+  const l = prompt.lang
+  const fighting = prompt.fight > 0
 
-    return (
-        <PanelItem storageKey="commands" title={t('cmd.title', l)}>
-            <div id="commands-table" className="flexcontainer-row collapse show">
-                <div className="flexcontainer-column">
-                    <button type="button" className="btn btn-ctrl-panel" data-action="см">{t('cmd.look', l)}</button>
-                    <button type="button" className="btn btn-ctrl-panel" data-action="инв">{t('cmd.inv', l)}</button>
-                    <button type="button" className="btn btn-ctrl-panel" data-action="одежда">{t('cmd.equip', l)}</button>
-                    <button type="button" className="btn btn-ctrl-panel" data-action="ссчет">{t('cmd.score', l)}</button>
-                    <button type="button" className="btn btn-ctrl-panel" data-action="/">{t('cmd.recall', l)}</button>
-                    <button type="button" className="btn btn-ctrl-panel" data-action="сбежать">{t('cmd.flee', l)}</button>
-                </div>
-                <div className="flexcontainer-column">
-                    <button type="button" className="btn btn-ctrl-panel" data-action="прак">{t('cmd.practice', l)}</button>
-                    <button type="button" className="btn btn-ctrl-panel" data-action="умения заклинания">{t('cmd.magic', l)}</button>
-                    <button type="button" className="btn btn-ctrl-panel" data-action="умения навыки">{t('cmd.skills', l)}</button>
-                    <button type="button" className="btn btn-ctrl-panel" data-action="задания">{t('cmd.quests', l)}</button>
-                    <button type="button" className="btn btn-ctrl-panel" data-action="команды">{t('cmd.title', l)}</button>
-                    <button type="button" className="btn btn-ctrl-panel" data-action="конец" data-confirm={t('cmd.quitConfirm', l)}>{t('cmd.quit', l)}</button>
-                </div>
-            </div>
-        </PanelItem>
-    )
+  // Peace-time buttons, in the order they were always in. 'flee' is not here:
+  // it is the one command in the set that only exists inside a fight.
+  const info = ['look', 'inv', 'equip', 'score']
+  const std = (key, confirm) => (
+    <Btn key={key} action={word(key, l)} label={t('cmd.' + key, l)} confirm={confirm} />
+  )
+
+  let items
+
+  if (fighting) {
+    // The server sends the combat actions this character can use right now
+    // (webprompt 'fcmd': flee, recall, then their own class and clan skills).
+    // "none" or a server that predates the field leaves us the two escapes,
+    // which every character has anyway.
+    const fcmd = Array.isArray(prompt.fcmd) ? prompt.fcmd : []
+    const actions = fcmd.length > 0 ? fcmd : [word('flee', l), word('recall', l)]
+
+    items = actions
+      .map(cmd => <Btn key={'f:' + cmd} action={cmd} label={capitalize(cmd)} combat />)
+      // Looking around and checking your own state stay useful mid-fight;
+      // practicing, browsing skills or quitting do not.
+      .concat(info.map(key => std(key)))
+  } else {
+    items = ['look', 'inv', 'equip', 'score', 'recall', 'practice']
+      .concat(
+        // Hide the spell list from characters who have no spells to list
+        // (webprompt 'sp'). An older server sends nothing, so keep the button.
+        prompt.sp === 0 ? [] : ['magic']
+      )
+      .concat(['skills', 'quests', 'commands'])
+      .map(key => std(key))
+      .concat(std('quit', t('cmd.quitConfirm', l)))
+  }
+
+  // Two columns, filled top-down: the taller one first, so an odd count leaves
+  // the gap on the right where the eye expects it.
+  const half = Math.ceil(items.length / 2)
+
+  return (
+    <PanelItem storageKey="commands" title={t('cmd.title', l)}>
+      <div id="commands-table" className="flexcontainer-row collapse show">
+        <div className="flexcontainer-column">{items.slice(0, half)}</div>
+        <div className="flexcontainer-column">{items.slice(half)}</div>
+      </div>
+    </PanelItem>
+  )
 }

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -104,8 +104,9 @@ const STRINGS = {
     'cmd.magic': 'Spells',
     'cmd.skills': 'Skills',
     'cmd.quests': 'Quests',
+    'cmd.commands': 'Commands',
     'cmd.quit': 'Quit',
-    'cmd.quitConfirm': 'leave the world',
+    'cmd.quitConfirm': 'Really leave the world?',
     // help search panel
     'help.title': 'Help search',
     'help.placeholder': 'Enter a keyword',
@@ -133,12 +134,15 @@ const STRINGS = {
     // Echo verbs for clickable links. The command SENT is always the canonical
     // English one; these are only what gets echoed into the player's own
     // scrollback, so they follow the display language the way a typed command
-    // would. Values mirror <name l="..."> in dreamland_world/commands.
-    'cmd.read': 'read',
-    'cmd.look': 'look',
-    'cmd.help': 'help',
-    'cmd.glist': 'glist',
-    'cmd.run': 'run',
+    // would. Values mirror <name l="..."> in dreamland_world/commands. Kept in
+    // their own "echo." namespace: as "cmd.look" they silently overwrote the
+    // panel button label of the same key, since a later key wins in an object
+    // literal.
+    'echo.read': 'read',
+    'echo.look': 'look',
+    'echo.help': 'help',
+    'echo.glist': 'glist',
+    'echo.run': 'run',
   },
   ru: {
     'aff.title': 'Воздействия на тебе',
@@ -184,8 +188,9 @@ const STRINGS = {
     'cmd.magic': 'Магия',
     'cmd.skills': 'Умения',
     'cmd.quests': 'Задания',
+    'cmd.commands': 'Команды',
     'cmd.quit': 'Конец',
-    'cmd.quitConfirm': 'покинуть мир',
+    'cmd.quitConfirm': 'Действительно хочешь покинуть мир?',
     'help.title': 'Поиск по справке',
     'help.placeholder': 'Введи ключевое слово',
     'help.notFound': 'Справка не найдена',
@@ -204,11 +209,11 @@ const STRINGS = {
     'ov.unread': 'Непрочитано: %d',
     'term.historyLoaded': 'ИСТОРИЯ ЧАТА ЗАГРУЖЕНА',
     'ph.example': 'Введи команду, например: %s',
-    'cmd.read': 'читать',
-    'cmd.look': 'смотреть',
-    'cmd.help': 'помощь',
-    'cmd.glist': 'группаумений',
-    'cmd.run': 'бежать',
+    'echo.read': 'читать',
+    'echo.look': 'смотреть',
+    'echo.help': 'помощь',
+    'echo.glist': 'группаумений',
+    'echo.run': 'бежать',
   },
   ua: {
     'aff.title': 'Впливи на тебе',
@@ -254,8 +259,9 @@ const STRINGS = {
     'cmd.magic': 'Магія',
     'cmd.skills': 'Уміння',
     'cmd.quests': 'Завдання',
+    'cmd.commands': 'Команди',
     'cmd.quit': 'Вихід',
-    'cmd.quitConfirm': 'покинути світ',
+    'cmd.quitConfirm': 'Справді хочеш покинути світ?',
     'help.title': 'Пошук у довідці',
     'help.placeholder': 'Введи ключове слово',
     'help.notFound': 'Довідку не знайдено',
@@ -274,11 +280,11 @@ const STRINGS = {
     'ov.unread': 'Непрочитано: %d',
     'term.historyLoaded': 'ІСТОРІЯ ЧАТУ ЗАВАНТАЖЕНА',
     'ph.example': 'Введи команду, наприклад: %s',
-    'cmd.read': 'читати',
-    'cmd.look': 'дивитися',
-    'cmd.help': 'допомога',
-    'cmd.glist': 'групавмінь',
-    'cmd.run': 'бігти',
+    'echo.read': 'читати',
+    'echo.look': 'дивитися',
+    'echo.help': 'допомога',
+    'echo.glist': 'групавмінь',
+    'echo.run': 'бігти',
   },
 };
 

--- a/src/main.css
+++ b/src/main.css
@@ -826,3 +826,17 @@ body.mud-fighting .terminal-wrap {
 body.mud-fighting form#input {
   border-color: #cc0000;
 }
+
+/* Combat actions in the button panel (commandButtons.jsx swaps the set while
+   fighting). Same red as the input stroke, so the whole client reads as one
+   state. Colour is never the only signal: these buttons carry different
+   commands and different labels, which is what a screen reader announces. */
+.btn-ctrl-panel.btn-combat {
+  background-color: #cc0000;
+  color: #fff;
+}
+
+.btn-ctrl-panel.btn-combat:hover {
+  background-color: #a30000;
+  color: #fff;
+}

--- a/src/manip.js
+++ b/src/manip.js
@@ -9,11 +9,8 @@ $(document).ready(function () {
     var cmd = $(e.currentTarget).attr('data-action');
     var conf = $(e.currentTarget).attr('data-confirm');
 
-    if (
-      conf !== undefined &&
-      !window.confirm('Вы действительно хотите ' + conf + '?')
-    )
-      return;
+    // data-confirm carries the whole question, already in the player's language.
+    if (conf !== undefined && !window.confirm(conf)) return;
 
     echo(cmd);
     send(cmd);
@@ -90,7 +87,7 @@ function manipParseAndReplace(span) {
       return (
         '<span class="manip-cmd manip-ed" data-action="read \'' +
         p1 +
-        '\'" data-echo="' + t('cmd.read') + ' ' +
+        '\'" data-echo="' + t('echo.read') + ' ' +
         p2 +
         '">' +
         p2 +
@@ -107,7 +104,7 @@ function manipParseAndReplace(span) {
       return (
         '<span class="manip-cmd manip-ed" data-action="look ' +
         p1 +
-        '" data-echo="' + t('cmd.look') + ' ' +
+        '" data-echo="' + t('echo.look') + ' ' +
         p2 +
         '">' +
         p2 +
@@ -229,7 +226,7 @@ function manipParseAndReplace(span) {
           .addClass('manip-cmd')
           .addClass('manip-link')
           .attr('data-action', 'help ' + id)
-          .attr('data-echo', t('cmd.help') + ' ' + id)
+          .attr('data-echo', t('echo.help') + ' ' + id)
           .append(label)
           .get(0).outerHTML +
         '&nbsp;'.repeat(spaceEnd);
@@ -245,7 +242,7 @@ function manipParseAndReplace(span) {
       var result = $('<span/>')
         .addClass('manip-cmd')
         .attr('data-action', 'glist ' + article.text())
-        .attr('data-echo', t('cmd.glist') + ' ' + article.text())
+        .attr('data-echo', t('echo.glist') + ' ' + article.text())
         .append(article);
       return result;
     });
@@ -260,7 +257,7 @@ function manipParseAndReplace(span) {
         .addClass('manip-cmd')
         .addClass('manip-speedwalk')
         .attr('data-action', 'run ' + article.text())
-        .attr('data-echo', t('cmd.run') + ' ' + article.text())
+        .attr('data-echo', t('echo.run') + ' ' + article.text())
         .append(article);
       return result;
     });


### PR DESCRIPTION
The button panel showed the same twelve commands whether you were browsing a temple or being eaten alive. `flee` sat there uselessly in peace, the score button opened `oscore` (the classic sheet, not the compact one), and every button sent a Russian command word that `manip.js` echoed straight into an English or Ukrainian player's own scrollback.

**In a fight** the panel leads with the combat actions the server says this character can use right now (prompt `fcmd`: flee, recall, then their own class and clan skills), painted the same red as the command input, followed by the four things still worth doing mid-fight -- look, inventory, equipment, score. Practicing, browsing skills and quitting drop out.

**In peace** the combat-only commands are gone. `recall` stays in both sets: it is a `cat=move` skill every class has at level 1 that works perfectly well outside a fight, so hiding it would cost a useful button for the sake of symmetry.

**Language.** Every button sends the command in the player's own display language (`WORDS` table, sourced from `<name>`/`<aliases>` in `dreamland_world/commands`). All 36 words were checked against the per-language priority tables to confirm each resolves to the intended command, and the riskier ones smoke-tested on live.

**Spell button** hides itself when the server says the character has no spells to list (prompt `sp`).

Both new prompt fields come from dreamland_code#873 and only appear after a reboot. Until then this degrades cleanly: the spell button stays, and the combat set falls back to flee + recall.

Also fixed along the way:

- `cmd.look` was defined twice per language in `i18n.js` -- once as the panel button label, once as an echo verb for clickable links -- and the later key silently won, so the button read "смотреть" instead of "Смотреть". Echo verbs now live in their own `echo.*` namespace.
- the quit confirmation asked "Вы действительно хотите покинуть мир?" in hardcoded Russian no matter the display language.

Colour is never the only signal: combat buttons carry different commands and different labels. (The panel itself is `aria-hidden`, so screen-reader users are unaffected either way.)