### PR TITLE
Point the map button at the redesigned maps page

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -2,7 +2,6 @@ import $ from 'jquery';
 import PropertiesStorage from './properties';
 import { connect } from './websock';
 import lastLocation from './location';
-import getSessionId from './sessionid.js';
 import historydb from './historydb';
 import { startAutoUpdate } from './autoupdate';
 
@@ -17,7 +16,6 @@ import './cs';
 
 import './main.css';
 
-const sessionId = getSessionId();
 let propertiesStorage = PropertiesStorage;
 
 $(window).bind('beforeunload', function () {
@@ -82,9 +80,14 @@ $(document).ready(function () {
       return;
     }
 
+    /* Open the zone on the maps page of the current site. This used to point at
+     * /maps/<zone>.html?sessionId=... -- the pre-redesign per-zone page, which is
+     * now only served by the legacy Russian site, so an English or Ukrainian
+     * player landed on a Russian page. The redesigned page selects the zone from
+     * the hash (see manip.js, which already links this way) and has no GPS
+     * follower, so sessionId has nothing left to feed. */
     var basefilename = lastLocation().area.replace(/\.are$/, '');
-    var mapfile = '/maps/' + basefilename + '.html?sessionId=' + sessionId;
-    window.open(mapfile);
+    window.open('https://dreamland.rocks/maps.html#' + basefilename);
   });
 
   connect();


### PR DESCRIPTION
Reported by Ruffina: *"'map' mudjs button leads to the old RU website"*.

The overlay map button opened `/maps/<zone>.html?sessionId=...`. Those per-zone pages are gone from the redesigned site -- `static/maps/` holds only assets now -- and the path falls through to the legacy Russian site:

```
$ curl -s https://dreamland.rocks/maps/midgaard.html | head -1
<html lang="ru">
...<title>DreamLand MUD - Карта зоны Мидгаард</title>
```

So every English and Ukrainian player got a Russian page.

`manip.js` already links the help article's "open the map" button at `https://dreamland.rocks/maps.html#<zone>`; the button now does the same. The zone key matches: `maps.js` selects from `location.hash` against `maps-index.json`'s `file` field, which is the bare zone name (`midgaard`), exactly what both call sites produce.

`sessionId` is dropped because the redesigned page has no GPS follower to consume it, and the import with it. `esbuild --bundle` is clean.

Note for the other half of that report -- the help button opening the **Ukrainian** site -- that is the site's own remembered language preference, which Ruffina guessed correctly in the report. Left alone here; passing the client language through to the map page would be a site change, not a client one.