### PR TITLE
Show the season instead of the year in the time widget

### DIFF
--- a/src/components/windowletsPanel/timeWeatherItem.jsx
+++ b/src/components/windowletsPanel/timeWeatherItem.jsx
@@ -20,14 +20,16 @@ const TimeRow = ({ h, tod, l }) => (
 );
 
 /**
- * Prompt date fields: d - day, m - month, y - year.
+ * Prompt date fields: d - day, m - month, s - season, y - year.
+ * The year is deliberately not shown: it never changes within a session, while
+ * the season does and is worth the space. It still arrives in the prompt.
  */
-const DateRow = ({ d, m, y }) => (
+const DateRow = ({ d, m, s }) => (
   <TableRow>
     <TableCell sx={{ textAlign: 'left' }}>
       <i className="fa">&#xf073;</i>
     </TableCell>
-    <TableCell>{`${d} / ${m} / ${y}`}</TableCell>
+    <TableCell>{`${d} / ${m}`}{s && ` / ${s}`}</TableCell>
   </TableRow>
 );
 


### PR DESCRIPTION
Trello: https://trello.com/c/v3KgsGTt

The date line becomes `day / month / season`. The year is dropped from the display -- it never changes within a session, the season does, and the row was already the densest in the widget.

Degrades safely: the season only renders once `date.s` arrives, so this can merge and deploy before the engine change (dreamland_code) reaches a reboot. Until then the line reads `day / month`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)