### PR TITLE
Resolve gender switches in en/ua map text, add a rage vignette

### DIFF
--- a/src/combatui.js
+++ b/src/combatui.js
@@ -14,5 +14,10 @@ $(function () {
   $('#rpc-events').on('rpc-prompt', function () {
     const fighting = !!(window.mudprompt && window.mudprompt.fight > 0);
     document.body.classList.toggle('mud-fighting', fighting);
+    // Berserk or frenzy (prompt.rage, set in interprethandler.cpp): same heartbeat,
+    // several times heavier, so rage reads as blood over the whole view. Gated on
+    // fighting -- a rage buff still ticking in town shouldn't paint the client red.
+    const raging = fighting && !!(window.mudprompt && window.mudprompt.rage);
+    document.body.classList.toggle('mud-rage', raging);
   });
 });

--- a/src/components/mapper/flexer.js
+++ b/src/components/mapper/flexer.js
@@ -27,9 +27,25 @@ export function resolveFlexer(text, sex) {
 }
 
 /**
+ * Resolve the name/description pair of one entity. Returns null when nothing changed,
+ * so callers can keep the original object and its identity.
+ */
+function resolveEntity(entity, sex) {
+  if (entity == null) return null;
+  const name = resolveFlexer(entity.name, sex);
+  const description = resolveFlexer(entity.description, sex);
+  if (name === entity.name && description === entity.description) return null;
+  return { ...entity, name, description };
+}
+
+/**
  * Return a copy of an area layout with every room name/description resolved for `sex`.
  * Layouts without any flexer switch (the common case) are returned by identity, so the
  * heavy d3 map and downstream effects don't see a fresh object on every sex/area tick.
+ *
+ * The base fields are the RUSSIAN text. An en/ua player reads room.i18n[loc] instead
+ * (i18n.ts nameFor/descFor), and those overrides carry their own switches -- resolve
+ * them too, or the map shows raw {Sm…{Sf…{Sx to everyone outside RU.
  */
 export function resolveLayoutFlexer(layout, sex) {
   if (layout == null) return layout;
@@ -37,10 +53,22 @@ export function resolveLayoutFlexer(layout, sex) {
   const rooms = {};
   for (const vnum in layout.rooms) {
     const room = layout.rooms[vnum];
-    const name = resolveFlexer(room.name, sex);
-    const description = resolveFlexer(room.description, sex);
-    if (name !== room.name || description !== room.description) {
-      rooms[vnum] = { ...room, name, description };
+    const base = resolveEntity(room, sex);
+
+    let i18n = null;
+    if (room.i18n != null) {
+      const en = resolveEntity(room.i18n.en, sex);
+      const ua = resolveEntity(room.i18n.ua, sex);
+      if (en != null || ua != null) {
+        i18n = { ...room.i18n };
+        if (en != null) i18n.en = en;
+        if (ua != null) i18n.ua = ua;
+      }
+    }
+
+    if (base != null || i18n != null) {
+      rooms[vnum] = { ...(base || room) };
+      if (i18n != null) rooms[vnum].i18n = i18n;
       touched = true;
     } else {
       rooms[vnum] = room;

--- a/src/main.css
+++ b/src/main.css
@@ -814,6 +814,31 @@ form#input {
 body.mud-fighting .terminal-wrap {
   animation: combat-heartbeat 1.15s infinite;
 }
+/* Berserk / frenzy: the same beat with ~3.5x the reach and ~3.5x the alpha, so the
+   blood covers the view instead of hinting at the edges. combatui.js sets .mud-rage
+   only together with .mud-fighting; the compound selector keeps it winning here. */
+@keyframes combat-heartbeat-rage {
+  0% {
+    box-shadow:
+      inset 0 0 330px 0 rgba(204, 0, 0, 0.45),
+      inset 0 0 660px 0 rgba(204, 0, 0, 0.21);
+    animation-timing-function: linear;
+  }
+  14% {
+    box-shadow:
+      inset 0 0 575px 0 rgba(204, 0, 0, 0.84),
+      inset 0 0 1150px 0 rgba(204, 0, 0, 0.42);
+    animation-timing-function: ease-out;
+  }
+  100% {
+    box-shadow:
+      inset 0 0 330px 0 rgba(204, 0, 0, 0.45),
+      inset 0 0 660px 0 rgba(204, 0, 0, 0.21);
+  }
+}
+body.mud-fighting.mud-rage .terminal-wrap {
+  animation-name: combat-heartbeat-rage;
+}
 /* Respect reduced-motion: hold a steady mid-strength glow instead of pulsing. */
 @media (prefers-reduced-motion: reduce) {
   body.mud-fighting .terminal-wrap {
@@ -821,6 +846,15 @@ body.mud-fighting .terminal-wrap {
     box-shadow:
       inset 0 0 150px 0 rgba(204, 0, 0, 0.2),
       inset 0 0 300px 0 rgba(204, 0, 0, 0.1);
+  }
+  body.mud-fighting.mud-rage .terminal-wrap {
+    /* The rage rule above out-specifies `animation: none`, so kill the name here
+       too. Without this, giving that rule a duration would silently restore the
+       pulse for people who asked for no motion. */
+    animation-name: none;
+    box-shadow:
+      inset 0 0 525px 0 rgba(204, 0, 0, 0.7),
+      inset 0 0 1050px 0 rgba(204, 0, 0, 0.35);
   }
 }
 body.mud-fighting form#input {


### PR DESCRIPTION
Two fixes from a live playthrough.

**Map showed raw gender switches to non-Russian players.** `resolveLayoutFlexer` only walked `room.name` / `room.description`, which are the Russian base fields, but `nameFor()` / `descFor()` read `room.i18n[loc]` for en and ua. So a Ukrainian player got `Ти видер{Smся{Sfлася{Sx на марс` in the side panel while a Russian one got clean text. Now the i18n overrides are resolved too, with object identity preserved in every branch so the d3 map is not handed a fresh layout on each tick.

**Rage vignette.** The combat heartbeat runs at ~3.5x reach and alpha while berserk or frenzy is up, driven by the new `prompt.rage` field (dreamland_code side). Gated on also being in combat, so a rage buff ticking in town paints nothing. Reduced-motion gets a steady wash instead of a pulse, with an `animation-name: none` guard so a future duration on the rage rule cannot re-enable motion for people who asked for none.

Degrades gracefully if only one side deploys: an absent `rage` field is falsy, an unused field is ignored.

Reviewed adversarially (two rounds, RELEASE).

🤖 Generated with [Claude Code](https://claude.com/claude-code)