### PR TITLE
affects widget: maladictions first + wrap to fit width

### DIFF
--- a/src/components/windowletsPanel/affectsItem.jsx
+++ b/src/components/windowletsPanel/affectsItem.jsx
@@ -7,11 +7,11 @@ import { t } from '../../i18n';
 // Duration only adds two overrides on top: permanent = cyan (6), about to expire = yellow (3).
 // See affColor().
 const COLUMNS = [
+    { key: 'mal', type: 'malad',   color: '1' },   // maladictions/curses first: bad news leads
     { key: 'pro', type: 'protect', color: '2' },
     { key: 'det', type: 'detects', color: '2' },
     { key: 'trv', type: 'travel',  color: '2' },
     { key: 'enh', type: 'enhance', color: '2' },
-    { key: 'mal', type: 'malad',   color: '1' },
     { key: 'cln', type: 'clan',    color: '2' },
 ];
 

--- a/src/main.css
+++ b/src/main.css
@@ -229,6 +229,9 @@ td.v-bottom {
   padding-left: 5px;
   padding-right: 5px;
   padding-bottom: 5px;
+  /* content-sized so columns pack side-by-side and wrap to fit the widget
+     width, instead of the shared 100% that forced overflow/one-per-row */
+  width: auto;
 }
 
 #questor-table p {
@@ -505,12 +508,10 @@ td.v-bottom {
 /*
  * Custom definition of flex with all the prefixes defined.
  */
-/* Replacing flex wrap with stretching
-/*
 .flexcontainer-wrap {
     flex-wrap: wrap;
     -webkit-flex-wrap: wrap;
-}*/
+}
 
 .flex-grow-shrink-auto {
   -webkit-box-flex: 1 1 0%;


### PR DESCRIPTION
Maladictions/curses column ordered first; re-enable flex-wrap (was commented out) and content-size the affects columns so they wrap to fit the widget width instead of overflowing. Visual change -- needs an eyeball on live.

Reported by Dementia (bugs [3005]).

🤖 Generated with [Claude Code](https://claude.com/claude-code)