### PR TITLE
Title-case affect-panel chips (fixes lowercase 'aid')

### DIFF
--- a/src/components/windowletsPanel/affectsItem.jsx
+++ b/src/components/windowletsPanel/affectsItem.jsx
@@ -38,7 +38,7 @@ function affColor(aff, baseColor) {
 // Draw one column: the server already localized each affect's label `n`.
 function AffectBlock(props) {
     const rows = props.block.map(function (aff, idx) {
-        return <span key={idx} className={affColor(aff, props.color)}>{aff.n}</span>;
+        return <span key={idx} className={'aff-chip ' + affColor(aff, props.color)}>{aff.n}</span>;
     });
 
     if (rows.length === 0) return null;

--- a/src/main.css
+++ b/src/main.css
@@ -234,6 +234,15 @@ td.v-bottom {
   width: auto;
 }
 
+/* Auto-fallback affect labels (server webAbbrev) arrive lowercase -- the skill's
+   own name -- while curated <webLabel>s are already capitalized. Title-case the
+   chip so both paths read the same, e.g. "aid" -> "Aid". Browser capitalize is
+   Unicode-aware, so Cyrillic first letters case correctly too. Chips are single
+   words; column headers have no .aff-chip class, so they are untouched. */
+#player-affects-table .aff-chip {
+  text-transform: capitalize;
+}
+
 #questor-table p {
   padding: 4px 4px 0px 4px;
 }


### PR DESCRIPTION
In-game report: the `aid` affect renders lowercase in the affect widget. Auto-fallback labels come from the server's `webAbbrev()` (the skill's own lowercase name); curated `<webLabel>`s are capitalized. Adds `.aff-chip { text-transform: capitalize }` so both paths read Title-case. Only chip spans get the class; column headers are untouched. Deploys via drone, no MUD reboot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)