### PR TITLE
Extend the combat glow to more player states (blind/mind/poison/fade/hide)

### DIFF
--- a/src/combatui.js
+++ b/src/combatui.js
@@ -1,23 +1,54 @@
 import $ from 'jquery';
 
-// Combat UI accent: while the player is fighting, paint the client red -- a red
-// stroke on the command input and a faint red inner glow around the terminal --
-// so it's obvious at a glance that combat is live (matters most for players with
-// fightspam off, where a quiet round prints little or nothing).
+// State UI accent: paint the client with a coloured inner glow that reflects the
+// player's current state, so it's obvious at a glance without reading every line
+// (matters most for players with fightspam off, where a quiet round prints little).
 //
-// Driven by window.mudprompt.fight (>0 while fighting), which prompt.js keeps
-// current from every web prompt (interprethandler webPrompt -> prompt.fight).
-// We only toggle a body class; the styling lives in main.css (body.mud-fighting)
-// and auto-reverts the instant combat ends (fight drops back to 0). Imported
-// after ./prompt in main.js so window.mudprompt is already updated when we read it.
+// The terminal vignette shows ONE state at a time -- the most urgent wins (see the
+// priority list below) and lands on body[data-glow]; main.css draws the colour.
+// The red combat input stroke and the red command buttons are a separate combat
+// signal driven by body.mud-fighting, kept as-is.
+//
+// Every flag is a field prompt.js keeps current on window.mudprompt from each web
+// prompt (interprethandler.cpp webPrompt): fight, rage, blind, mind, poison, fade,
+// hide. Colour is never the only signal -- the affects panel and the game messages
+// carry the real state for screen readers; this is ambient flavour on top.
+//   blind  -> white, heavy (any AFF_BLIND: blindness spell, dirt kick...)
+//   mind   -> purple (charmed / magically asleep / stunned)
+//   fight  -> red heartbeat   (rage -> heavier red heartbeat)
+//   poison -> green, slow sick pulse
+//   fade   -> heavy grey (concealment, steady)
+//   hide   -> grey (concealment, steady)
+//
+// Imported after ./prompt in main.js so window.mudprompt is already updated here.
 $(function () {
   $('#rpc-events').on('rpc-prompt', function () {
-    const fighting = !!(window.mudprompt && window.mudprompt.fight > 0);
-    document.body.classList.toggle('mud-fighting', fighting);
-    // Berserk or frenzy (prompt.rage, set in interprethandler.cpp): same heartbeat,
-    // several times heavier, so rage reads as blood over the whole view. Gated on
-    // fighting -- a rage buff still ticking in town shouldn't paint the client red.
-    const raging = fighting && !!(window.mudprompt && window.mudprompt.rage);
-    document.body.classList.toggle('mud-rage', raging);
+    const p = window.mudprompt || {};
+    const body = document.body;
+
+    const fighting = p.fight > 0;
+    // Berserk or frenzy (prompt.rage): the same red beat, several times heavier,
+    // so rage reads as blood over the whole view. Gated on fighting -- a rage buff
+    // still ticking in town shouldn't paint the client red.
+    const raging = fighting && !!p.rage;
+
+    // Combat classes still drive the input stroke + red button panel.
+    body.classList.toggle('mud-fighting', fighting);
+    body.classList.toggle('mud-rage', raging);
+
+    // Single terminal vignette, most urgent state wins. Blind tops it (you can't
+    // see -- the white wash-out dominates), then mind, then combat, then the
+    // slower afflictions and the passive concealment glows.
+    const glow =
+      p.blind ? 'blind' :
+      p.mind ? 'mind' :
+      raging ? 'rage' :
+      fighting ? 'fight' :
+      p.poison ? 'poison' :
+      p.fade ? 'fade' :
+      p.hide ? 'hide' : '';
+
+    if (glow) body.dataset.glow = glow;
+    else delete body.dataset.glow;
   });
 });

--- a/src/main.css
+++ b/src/main.css
@@ -786,13 +786,20 @@ header.MuiPaper-root.MuiAppBar-root {
   }
 }
 
-/* --- Combat UI accent -------------------------------------------------------
- * src/combatui.js toggles body.mud-fighting while the player is fighting.
- * Paint a red stroke on the command input and a faint red inner glow around the
- * terminal so it's obvious combat is live; both fade in/out and revert the
- * instant combat ends. Placed last so it overrides the cyan focus stroke
- * (higher specificity than form#input:focus-within). The input border only
- * exists on big screens, so the red stroke shows there; the glow shows on all.
+/* --- State UI accent --------------------------------------------------------
+ * src/combatui.js resolves the player's most urgent state to body[data-glow]
+ * (blind > mind > rage > fight > poison > fade > hide) and, separately, toggles
+ * body.mud-fighting for the red input stroke + red command buttons. Here we draw
+ * one coloured inner vignette per state on .terminal-wrap: it fades in/out and
+ * reverts the instant the state clears. Placed last so it overrides the cyan
+ * focus stroke (higher specificity than form#input:focus-within). Colour is never
+ * the only signal -- the affects panel and the game messages carry the real state
+ * for screen readers; this is ambient flavour on top.
+ *   blind  -> white, heavy pulse (any AFF_BLIND: blindness spell, dirt kick...)
+ *   mind   -> purple, slow woozy pulse (charmed / asleep / stunned)
+ *   fight  -> red heartbeat        (rage -> heavier red heartbeat)
+ *   poison -> green, slow sick pulse
+ *   fade   -> heavy grey, steady   (hide -> light grey, steady)
  */
 .terminal-wrap,
 form#input {
@@ -821,12 +828,13 @@ form#input {
       inset 0 0 190px 0 rgba(204, 0, 0, 0.06);
   }
 }
-body.mud-fighting .terminal-wrap {
+body[data-glow="fight"] .terminal-wrap {
   animation: combat-heartbeat 1.15s infinite;
 }
 /* Berserk / frenzy: the same beat with ~3.5x the reach and ~3.5x the alpha, so the
-   blood covers the view instead of hinting at the edges. combatui.js sets .mud-rage
-   only together with .mud-fighting; the compound selector keeps it winning here. */
+   blood covers the view instead of hinting at the edges. Its own data-glow state
+   (combatui.js sets "rage" instead of "fight" while raging), so a full animation
+   here, not just an animation-name override. */
 @keyframes combat-heartbeat-rage {
   0% {
     box-shadow:
@@ -846,25 +854,112 @@ body.mud-fighting .terminal-wrap {
       inset 0 0 660px 0 rgba(204, 0, 0, 0.21);
   }
 }
-body.mud-fighting.mud-rage .terminal-wrap {
-  animation-name: combat-heartbeat-rage;
+body[data-glow="rage"] .terminal-wrap {
+  animation: combat-heartbeat-rage 1.15s infinite;
 }
-/* Respect reduced-motion: hold a steady mid-strength glow instead of pulsing. */
+/* Blind: white and heavy, berserk-strength -- the whole view washes out, the way
+   losing your sight should feel. Same heartbeat rhythm as rage; peak alpha pulled
+   a touch under rage's so light terminal text stays legible against the white. */
+@keyframes glow-blind {
+  0% {
+    box-shadow:
+      inset 0 0 330px 0 rgba(255, 255, 255, 0.40),
+      inset 0 0 660px 0 rgba(255, 255, 255, 0.19);
+    animation-timing-function: linear;
+  }
+  14% {
+    box-shadow:
+      inset 0 0 575px 0 rgba(255, 255, 255, 0.72),
+      inset 0 0 1150px 0 rgba(255, 255, 255, 0.36);
+    animation-timing-function: ease-out;
+  }
+  100% {
+    box-shadow:
+      inset 0 0 330px 0 rgba(255, 255, 255, 0.40),
+      inset 0 0 660px 0 rgba(255, 255, 255, 0.19);
+  }
+}
+body[data-glow="blind"] .terminal-wrap {
+  animation: glow-blind 1.15s infinite;
+}
+/* Mind (charmed / asleep / stunned): a slow purple breathe -- not the fast combat
+   beat but a woozy sway in and out, "you are not yourself". ease-in-out, 0<->50. */
+@keyframes glow-mind {
+  0%, 100% {
+    box-shadow:
+      inset 0 0 120px 0 rgba(150, 70, 205, 0.13),
+      inset 0 0 240px 0 rgba(150, 70, 205, 0.07);
+  }
+  50% {
+    box-shadow:
+      inset 0 0 175px 0 rgba(150, 70, 205, 0.26),
+      inset 0 0 350px 0 rgba(150, 70, 205, 0.13);
+  }
+}
+body[data-glow="mind"] .terminal-wrap {
+  animation: glow-mind 2.6s ease-in-out infinite;
+}
+/* Poison: a slow sickly-green breathe, like nausea rising and falling. */
+@keyframes glow-poison {
+  0%, 100% {
+    box-shadow:
+      inset 0 0 110px 0 rgba(70, 190, 80, 0.12),
+      inset 0 0 220px 0 rgba(70, 190, 80, 0.06);
+  }
+  50% {
+    box-shadow:
+      inset 0 0 160px 0 rgba(70, 190, 80, 0.22),
+      inset 0 0 320px 0 rgba(70, 190, 80, 0.11);
+  }
+}
+body[data-glow="poison"] .terminal-wrap {
+  animation: glow-poison 2.8s ease-in-out infinite;
+}
+/* Concealment: steady grey, no pulse -- you're lurking, the client is calm. Fade
+   is the heavier "double grey"; hide is a light hint at the edges. */
+body[data-glow="fade"] .terminal-wrap {
+  box-shadow:
+    inset 0 0 150px 0 rgba(150, 155, 165, 0.20),
+    inset 0 0 300px 0 rgba(150, 155, 165, 0.10);
+}
+body[data-glow="hide"] .terminal-wrap {
+  box-shadow:
+    inset 0 0 110px 0 rgba(150, 155, 165, 0.10),
+    inset 0 0 220px 0 rgba(150, 155, 165, 0.05);
+}
+/* Respect reduced-motion: hold each pulsing state at a steady mid-strength glow
+   instead of animating. Same specificity as the rules above, placed after them so
+   it wins. hide/fade are already steady, nothing to override there. */
 @media (prefers-reduced-motion: reduce) {
-  body.mud-fighting .terminal-wrap {
+  body[data-glow="fight"] .terminal-wrap {
     animation: none;
     box-shadow:
       inset 0 0 150px 0 rgba(204, 0, 0, 0.2),
       inset 0 0 300px 0 rgba(204, 0, 0, 0.1);
   }
-  body.mud-fighting.mud-rage .terminal-wrap {
-    /* The rage rule above out-specifies `animation: none`, so kill the name here
-       too. Without this, giving that rule a duration would silently restore the
-       pulse for people who asked for no motion. */
-    animation-name: none;
+  body[data-glow="rage"] .terminal-wrap {
+    animation: none;
     box-shadow:
       inset 0 0 525px 0 rgba(204, 0, 0, 0.7),
       inset 0 0 1050px 0 rgba(204, 0, 0, 0.35);
+  }
+  body[data-glow="blind"] .terminal-wrap {
+    animation: none;
+    box-shadow:
+      inset 0 0 520px 0 rgba(255, 255, 255, 0.6),
+      inset 0 0 1040px 0 rgba(255, 255, 255, 0.3);
+  }
+  body[data-glow="mind"] .terminal-wrap {
+    animation: none;
+    box-shadow:
+      inset 0 0 175px 0 rgba(150, 70, 205, 0.24),
+      inset 0 0 350px 0 rgba(150, 70, 205, 0.12);
+  }
+  body[data-glow="poison"] .terminal-wrap {
+    animation: none;
+    box-shadow:
+      inset 0 0 160px 0 rgba(70, 190, 80, 0.2),
+      inset 0 0 320px 0 rgba(70, 190, 80, 0.1);
   }
 }
 body.mud-fighting form#input {


### PR DESCRIPTION
Generalises the red combat vignette into a per-state inner glow.

`combatui.js` resolves the most urgent state to `body[data-glow]` (blind > mind > rage > fight > poison > fade > hide); `main.css` draws one coloured vignette per state:

| state | colour | motion |
|---|---|---|
| blind | white, heavy | heartbeat pulse |
| mind (charm/sleep/stun) | purple | slow woozy pulse |
| fight (rage) | red | heartbeat pulse |
| poison | green | slow sick pulse |
| fade | heavy grey | steady |
| hide | light grey | steady |

Red input stroke + red command buttons still key off `body.mud-fighting`, unchanged. Colour is never the only signal (affects panel + game messages carry it for screen readers); `prefers-reduced-motion` holds each pulsing state steady. State flags come from the web prompt (dreamland_code #1113, reboot-pending); client degrades safe without them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)