### PR TITLE
HP-driven heartbeat + near-death veil + faerie-fire glow

### DIFF
--- a/src/combatui.js
+++ b/src/combatui.js
@@ -9,16 +9,23 @@ import $ from 'jquery';
 // The red combat input stroke and the red command buttons are a separate combat
 // signal driven by body.mud-fighting, kept as-is.
 //
-// Every flag is a field prompt.js keeps current on window.mudprompt from each web
-// prompt (interprethandler.cpp webPrompt): fight, rage, blind, mind, poison, fade,
-// hide. Colour is never the only signal -- the affects panel and the game messages
-// carry the real state for screen readers; this is ambient flavour on top.
-//   blind  -> white, heavy (any AFF_BLIND: blindness spell, dirt kick...)
-//   mind   -> purple (charmed / magically asleep / stunned)
-//   fight  -> red heartbeat   (rage -> heavier red heartbeat)
-//   poison -> green, slow sick pulse
-//   fade   -> heavy grey (concealment, steady)
-//   hide   -> grey (concealment, steady)
+// The heartbeat also tracks HP (both client-only, no server flag): the fight/rage/
+// near-death pulse quickens as you bleed out (body --beat, from hit/max_hit), and
+// under 25% HP the whole vignette turns to a heavy dark-crimson throb -- you're
+// dying, so that owns the view over any other state.
+//
+// State flags are fields prompt.js keeps current on window.mudprompt from each web
+// prompt (interprethandler.cpp webPrompt): fight, rage, blind, faerie, mind, poison,
+// fade, hide (+ hit/max_hit). Colour is never the only signal -- the affects panel
+// and the game messages carry the real state for screen readers; ambient flavour.
+//   neardeath -> dark crimson, heavy throb (<=25% HP; beats faster the lower you go)
+//   blind     -> white, heavy pulse (any AFF_BLIND: blindness spell, dirt kick...)
+//   mind      -> purple (charmed / magically asleep / stunned)
+//   fight     -> red heartbeat   (rage -> heavier red heartbeat)
+//   faerie    -> pink (faerie fire -- you're lit up, easier to hit)
+//   poison    -> green, slow sick pulse
+//   fade      -> heavy grey (concealment, steady)
+//   hide      -> grey (concealment, steady)
 //
 // Imported after ./prompt in main.js so window.mudprompt is already updated here.
 $(function () {
@@ -36,14 +43,30 @@ $(function () {
     body.classList.toggle('mud-fighting', fighting);
     body.classList.toggle('mud-rage', raging);
 
-    // Single terminal vignette, most urgent state wins. Blind tops it (you can't
-    // see -- the white wash-out dominates), then mind, then combat, then the
-    // slower afflictions and the passive concealment glows.
+    // Heartbeat rate tracks HP: the fight/rage/near-death pulse quickens as you
+    // bleed out, from 1.15s at full health toward ~0.55s near death (main.css reads
+    // var(--beat)). nearDeath at or below a quarter HP flips the vignette to a heavy
+    // dark-crimson throb that owns the view.
+    const maxHit = p.max_hit;
+    let nearDeath = false;
+    if (maxHit > 0) {
+      let frac = p.hit / maxHit;
+      if (frac < 0) frac = 0;
+      else if (frac > 1) frac = 1;
+      body.style.setProperty('--beat', (0.55 + 0.6 * frac).toFixed(2) + 's');
+      nearDeath = frac > 0 && frac <= 0.25;
+    }
+
+    // Single terminal vignette, most urgent state wins. Dying tops everything, then
+    // blind (you can't see -- the white wash-out dominates), then mind, then combat,
+    // then faerie fire, the slower afflictions, and the passive concealment glows.
     const glow =
+      nearDeath ? 'neardeath' :
       p.blind ? 'blind' :
       p.mind ? 'mind' :
       raging ? 'rage' :
       fighting ? 'fight' :
+      p.faerie ? 'faerie' :
       p.poison ? 'poison' :
       p.fade ? 'fade' :
       p.hide ? 'hide' : '';

--- a/src/main.css
+++ b/src/main.css
@@ -829,7 +829,9 @@ form#input {
   }
 }
 body[data-glow="fight"] .terminal-wrap {
-  animation: combat-heartbeat 1.15s infinite;
+  /* --beat (set by combatui.js from HP) quickens the pulse as you bleed out;
+     falls back to the resting 1.15s before the first prompt sets it. */
+  animation: combat-heartbeat var(--beat, 1.15s) infinite;
 }
 /* Berserk / frenzy: the same beat with ~3.5x the reach and ~3.5x the alpha, so the
    blood covers the view instead of hinting at the edges. Its own data-glow state
@@ -855,7 +857,32 @@ body[data-glow="fight"] .terminal-wrap {
   }
 }
 body[data-glow="rage"] .terminal-wrap {
-  animation: combat-heartbeat-rage 1.15s infinite;
+  animation: combat-heartbeat-rage var(--beat, 1.15s) infinite;
+}
+/* Near death (<=25% HP): a heavy dark-crimson throb that never fully recedes -- the
+   view sits under a crimson pall, beating at the same HP-driven rate as combat (fast
+   here, since you only see it when HP is low). Owns the vignette over any state. */
+@keyframes glow-neardeath {
+  0% {
+    box-shadow:
+      inset 0 0 300px 0 rgba(110, 0, 15, 0.44),
+      inset 0 0 600px 0 rgba(110, 0, 15, 0.22);
+    animation-timing-function: linear;
+  }
+  14% {
+    box-shadow:
+      inset 0 0 540px 0 rgba(110, 0, 15, 0.74),
+      inset 0 0 1080px 0 rgba(110, 0, 15, 0.40);
+    animation-timing-function: ease-out;
+  }
+  100% {
+    box-shadow:
+      inset 0 0 300px 0 rgba(110, 0, 15, 0.44),
+      inset 0 0 600px 0 rgba(110, 0, 15, 0.22);
+  }
+}
+body[data-glow="neardeath"] .terminal-wrap {
+  animation: glow-neardeath var(--beat, 1.15s) infinite;
 }
 /* Blind: white and heavy, berserk-strength -- the whole view washes out, the way
    losing your sight should feel. Same heartbeat rhythm as rage; peak alpha pulled
@@ -915,6 +942,23 @@ body[data-glow="mind"] .terminal-wrap {
 body[data-glow="poison"] .terminal-wrap {
   animation: glow-poison 2.8s ease-in-out infinite;
 }
+/* Faerie fire: a slow pink shimmer -- you're outlined in rosy light, easier to hit.
+   Pink, deliberately apart from the mind purple. Same slow breathe as poison. */
+@keyframes glow-faerie {
+  0%, 100% {
+    box-shadow:
+      inset 0 0 115px 0 rgba(235, 110, 185, 0.12),
+      inset 0 0 230px 0 rgba(235, 110, 185, 0.06);
+  }
+  50% {
+    box-shadow:
+      inset 0 0 165px 0 rgba(235, 110, 185, 0.23),
+      inset 0 0 330px 0 rgba(235, 110, 185, 0.115);
+  }
+}
+body[data-glow="faerie"] .terminal-wrap {
+  animation: glow-faerie 2.7s ease-in-out infinite;
+}
 /* Concealment: steady grey, no pulse -- you're lurking, the client is calm. Fade
    is the heavier "double grey"; hide is a light hint at the edges. */
 body[data-glow="fade"] .terminal-wrap {
@@ -943,6 +987,12 @@ body[data-glow="hide"] .terminal-wrap {
       inset 0 0 525px 0 rgba(204, 0, 0, 0.7),
       inset 0 0 1050px 0 rgba(204, 0, 0, 0.35);
   }
+  body[data-glow="neardeath"] .terminal-wrap {
+    animation: none;
+    box-shadow:
+      inset 0 0 500px 0 rgba(110, 0, 15, 0.62),
+      inset 0 0 1000px 0 rgba(110, 0, 15, 0.33);
+  }
   body[data-glow="blind"] .terminal-wrap {
     animation: none;
     box-shadow:
@@ -960,6 +1010,12 @@ body[data-glow="hide"] .terminal-wrap {
     box-shadow:
       inset 0 0 160px 0 rgba(70, 190, 80, 0.2),
       inset 0 0 320px 0 rgba(70, 190, 80, 0.1);
+  }
+  body[data-glow="faerie"] .terminal-wrap {
+    animation: none;
+    box-shadow:
+      inset 0 0 165px 0 rgba(235, 110, 185, 0.21),
+      inset 0 0 330px 0 rgba(235, 110, 185, 0.10);
   }
 }
 body.mud-fighting form#input {


### PR DESCRIPTION
Builds on #160.

- **HP heartbeat** — the fight/rage/near-death pulse quickens as HP drops (`body --beat` from `hit/max_hit`, ~1.15s full → ~0.55s near death). Client-only.
- **Near death** — at ≤25% HP the vignette flips to a heavy dark-crimson throb that owns the view over any other state. Client-only.
- **Faerie fire** — slow pink shimmer (you're lit up), pink kept apart from the mind purple. Flag from the web prompt (dreamland_code #1114, reboot-pending).

Priority: `neardeath > blind > mind > rage > fight > faerie > poison > fade > hide`. `prefers-reduced-motion` holds each pulsing state steady. HP effects live on deploy; faerie waits for the reboot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)